### PR TITLE
Add designation to main actor on recipe image data update

### DIFF
--- a/GymMealPrep/Recipe/ViewModels/RecipeViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeViewModel.swift
@@ -20,7 +20,7 @@ class RecipeViewModel: ObservableObject {
     @Published var selectedPhoto: PhotosPickerItem? = nil {
         didSet {
             if let selectedPhoto {
-                Task {
+                Task { @MainActor in 
                     recipe.imageData = try await loadTransferable(from: selectedPhoto)
                 }
             }


### PR DESCRIPTION
Task has to be run by main actor (on main thread) since the value it is updating is used to display UI. 
Added a @MainActor in the task closures that updates the data in recipe. 