### PR TITLE
Add UI testing for recipe list

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 			children = (
 				D6C7A2B82A63F0AE00A82757 /* Extensions */,
 				D634FFA229FD42F60034B950 /* GymMealPrepUITests.swift */,
+				D69684642A6420EA0064DD83 /* RecipeListUITests.swift */,
 				D661A44F2A5F4A0F005C0C5B /* RecipeCreatorUITests.swift */,
 				D634FFA429FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift */,
 			);
@@ -579,7 +580,6 @@
 			children = (
 				D6C7A2B92A63F0E400A82757 /* XCT+Focus.swift */,
 				D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */,
-				D69684642A6420EA0064DD83 /* RecipeListUITests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		D694E4072A05824A0077E72F /* IngredientMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3FB2A05824A0077E72F /* IngredientMO+CoreDataClass.swift */; };
 		D694E4082A05824A0077E72F /* IngredientMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */; };
 		D694E40D2A05824A0077E72F /* TagMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */; };
+		D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */; };
 		D69B9DC32A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */; };
 		D69B9DC52A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */; };
 		D69BAB212A2FE45900E2D05D /* InstructionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69BAB202A2FE45900E2D05D /* InstructionRowView.swift */; };
@@ -196,6 +197,7 @@
 		D694E3FB2A05824A0077E72F /* IngredientMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IngredientMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IngredientMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagMO+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Existance.swift"; sourceTree = "<group>"; };
 		D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorViewModelTests.swift; sourceTree = "<group>"; };
 		D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorInstructionsView.swift; sourceTree = "<group>"; };
 		D69BAB202A2FE45900E2D05D /* InstructionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionRowView.swift; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 			isa = PBXGroup;
 			children = (
 				D6C7A2B92A63F0E400A82757 /* XCT+Focus.swift */,
+				D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -846,6 +849,7 @@
 				D661A4502A5F4A0F005C0C5B /* RecipeCreatorUITests.swift in Sources */,
 				D634FFA529FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,
+				D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		D694E4082A05824A0077E72F /* IngredientMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */; };
 		D694E40D2A05824A0077E72F /* TagMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */; };
 		D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */; };
+		D69684652A6420EA0064DD83 /* RecipeListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684642A6420EA0064DD83 /* RecipeListUITests.swift */; };
 		D69B9DC32A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */; };
 		D69B9DC52A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */; };
 		D69BAB212A2FE45900E2D05D /* InstructionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69BAB202A2FE45900E2D05D /* InstructionRowView.swift */; };
@@ -198,6 +199,7 @@
 		D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IngredientMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Existance.swift"; sourceTree = "<group>"; };
+		D69684642A6420EA0064DD83 /* RecipeListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecipeListUITests.swift; path = GymMealPrepUITests/RecipeListUITests.swift; sourceTree = SOURCE_ROOT; };
 		D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorViewModelTests.swift; sourceTree = "<group>"; };
 		D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorInstructionsView.swift; sourceTree = "<group>"; };
 		D69BAB202A2FE45900E2D05D /* InstructionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionRowView.swift; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 			children = (
 				D6C7A2B92A63F0E400A82757 /* XCT+Focus.swift */,
 				D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */,
+				D69684642A6420EA0064DD83 /* RecipeListUITests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -846,6 +849,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6C7A2BA2A63F0E400A82757 /* XCT+Focus.swift in Sources */,
+				D69684652A6420EA0064DD83 /* RecipeListUITests.swift in Sources */,
 				D661A4502A5F4A0F005C0C5B /* RecipeCreatorUITests.swift in Sources */,
 				D634FFA529FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,

--- a/GymMealPrep/ContentView.swift
+++ b/GymMealPrep/ContentView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject var backgroundColor: DependancyContainer
     
     var body: some View {
         TabView {
@@ -17,6 +18,7 @@ struct ContentView: View {
                     Image(systemName: "house.fill")
                     Text("Home")
                 }
+                .background(backgroundColor.signalColor)
             
             RecipeListTabView()
                     .tabItem {

--- a/GymMealPrep/ContentView.swift
+++ b/GymMealPrep/ContentView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ContentView: View {
-    @EnvironmentObject var backgroundColor: DependancyContainer
     
     var body: some View {
         TabView {
@@ -18,7 +17,6 @@ struct ContentView: View {
                     Image(systemName: "house.fill")
                     Text("Home")
                 }
-                .background(backgroundColor.signalColor)
             
             RecipeListTabView()
                     .tabItem {

--- a/GymMealPrep/DataManager/DataManager.swift
+++ b/GymMealPrep/DataManager/DataManager.swift
@@ -29,11 +29,18 @@ class DataManager: NSObject, ObservableObject {
     
     //MARK: INIT
     private init(type: DataManagerType) {
+        //set a flag for running UI tests
+        let isRunningUITests = CommandLine.arguments.contains("-UITests")
         //Set container depending on type
         switch type {
         case .normal:
-            let persistanceContainer = PersistanceContainer()
-            self.managedContext = persistanceContainer.viewContext
+            if isRunningUITests {
+                let persistanceContainer = PersistanceContainer(inMemory: true)
+                self.managedContext = persistanceContainer.viewContext
+            } else {
+                let persistanceContainer = PersistanceContainer()
+                self.managedContext = persistanceContainer.viewContext
+            }
         case .testing:
             let persistanceContainer = PersistanceContainer(inMemory: true)
             self.managedContext = persistanceContainer.viewContext
@@ -53,7 +60,7 @@ class DataManager: NSObject, ObservableObject {
         super.init()
         recipeFRC.delegate = self
         mealPlanFRC.delegate = self
-        if type == .preview {
+        if type == .preview || isRunningUITests {
             addPreviewData()
         }
         //Initial fetches

--- a/GymMealPrep/GymMealPrepApp.swift
+++ b/GymMealPrep/GymMealPrepApp.swift
@@ -7,11 +7,27 @@
 
 import SwiftUI
 
+class DependancyContainer: ObservableObject {
+    let signalColor: Color
+    
+    init() {
+        self.signalColor = {
+            if CommandLine.arguments.contains("-UITests") {
+                return Color.blue
+            } else {
+                return Color.red
+            }
+        }()
+    }
+}
+
 @main
 struct GymMealPrepApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(DependancyContainer())
         }
+        
     }
 }

--- a/GymMealPrep/GymMealPrepApp.swift
+++ b/GymMealPrep/GymMealPrepApp.swift
@@ -7,26 +7,11 @@
 
 import SwiftUI
 
-class DependancyContainer: ObservableObject {
-    let signalColor: Color
-    
-    init() {
-        self.signalColor = {
-            if CommandLine.arguments.contains("-UITests") {
-                return Color.blue
-            } else {
-                return Color.red
-            }
-        }()
-    }
-}
-
 @main
 struct GymMealPrepApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(DependancyContainer())
         }
         
     }

--- a/GymMealPrep/Recipe/RecipeListViews/RecipeListView.swift
+++ b/GymMealPrep/Recipe/RecipeListViews/RecipeListView.swift
@@ -30,7 +30,7 @@ struct RecipeListView: View {
                 
             } // END OF LIST
             .listStyle(.plain)
-            .navigationTitle("Recipies")
+            .navigationTitle("Recipes")
             
             .toolbar {
                 

--- a/GymMealPrepUITests/Extensions/XCUIElement+Existance.swift
+++ b/GymMealPrepUITests/Extensions/XCUIElement+Existance.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+import XCTest
+
+extension XCUIElement {
+    func waitForNonExistence(timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        _ = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        return !exists
+    }
+}

--- a/GymMealPrepUITests/Extensions/XCUIElement+Existance.swift
+++ b/GymMealPrepUITests/Extensions/XCUIElement+Existance.swift
@@ -1,0 +1,8 @@
+//
+//  XCUIElement+Existance.swift
+//  GymMealPrepUITests
+//
+//  Created by Tomasz Kubiak on 7/16/23.
+//
+
+import Foundation

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -8,18 +8,24 @@
 import XCTest
 
 final class RecipeListUITests: XCTestCase {
+    
+    //MARK: INFORMATION ABOUT NAMING
+    /*
+     Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour
+     Naming structure: test_[Struct or class]_[UI component]_[expected result]
+     Testing structure: Given, When, Then
+     */
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
+    var app: XCUIApplication!
+    
+    override func setUp() {
+        app = XCUIApplication()
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app.launch()
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        app = nil
     }
 
     func testExample() throws {

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -29,19 +29,8 @@ final class RecipeListUITests: XCTestCase {
     }
 
     func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
+        
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
+        
     }
 }

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -1,0 +1,41 @@
+//
+//  RecipeListUITests.swift
+//  GymMealPrepUITests
+//
+//  Created by Tomasz Kubiak on 7/16/23.
+//
+
+import XCTest
+
+final class RecipeListUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -42,6 +42,31 @@ final class RecipeListUITests: XCTestCase {
         let result = navTitleText.waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Recipe navigation title should exist")
     }
+    
+    func test_RecipeList_UIComponents_arePresent() throws {
+        // Given
+        navigateToRecipeList()
+        
+        let recipesNavigationBar = app.navigationBars["Recipes"]
+        let navTitleText = recipesNavigationBar.staticTexts["Recipes"]
+        let addButton = recipesNavigationBar.buttons["Add"]
+        let chevronLeftButton = recipesNavigationBar.images["Back"]
+        let addFromTextButton = recipesNavigationBar.buttons["Add from text"]
+        
+        // When
+        chevronLeftButton.tap()
+        
+        //Then
+        let existsPredicate = NSPredicate(format: "exists == true")
+        let expectations = [
+        expectation(for: existsPredicate, evaluatedWith: navTitleText),
+        expectation(for: existsPredicate, evaluatedWith: addButton),
+        expectation(for: existsPredicate, evaluatedWith: chevronLeftButton),
+        expectation(for: existsPredicate, evaluatedWith: addFromTextButton)
+        ]
+        let testResult = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(testResult, .completed, "All of the elements should exists")
+    }
 }
 
 extension RecipeListUITests {

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -23,6 +23,7 @@ final class RecipeListUITests: XCTestCase {
     override func setUp() {
         app = XCUIApplication()
         continueAfterFailure = false
+        app.launchArguments = ["-UITests"]
         app.launch()
     }
 

--- a/GymMealPrepUITests/RecipeListUITests.swift
+++ b/GymMealPrepUITests/RecipeListUITests.swift
@@ -18,6 +18,8 @@ final class RecipeListUITests: XCTestCase {
 
     var app: XCUIApplication!
     
+    let standardTimeout = 2.5
+    
     override func setUp() {
         app = XCUIApplication()
         continueAfterFailure = false
@@ -28,9 +30,23 @@ final class RecipeListUITests: XCTestCase {
         app = nil
     }
 
-    func testExample() throws {
+    func test_RecipeList_TabBar_shouldNavigateToList() throws {
+        // Given
+        // captured in setup
         
+        // When
+        navigateToRecipeList()
+        
+        // Then
+        let navTitleText = app.navigationBars["Recipes"].staticTexts["Recipes"]
+        let result = navTitleText.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Recipe navigation title should exist")
+    }
+}
 
-        
+extension RecipeListUITests {
+    
+    func navigateToRecipeList() {
+        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
     }
 }


### PR DESCRIPTION
To improve test coverage and ensure that no functionality is broken UI tests are needed. 
This PR adds 2 simple UI tests, as well as implements running test with data manager set with specific pre populated data. This ensures that the future tests are not failing due to changed conditions in persistent storage, as well as the tests not affecting the persistent storage on the simulator/testing device. 

I added conditions that make the shared instance of data manager run with in memory container and populate that container with data available in previews. 
I added UI test checking if navigation using tab bar to recipe lists results in recipe list appearing 
I added UI test checking that all of the UI components are present after navigating to Recipe list view