### PR TITLE
Remove designation to show preview data manager, replace with calling…

### DIFF
--- a/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
+++ b/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
@@ -39,7 +39,7 @@ struct MealPlanEditorSheetView: View {
                                        pickerViewModel: IngredientPickerViewModel())
                 case .recipe:
                     RecipePickerView(saveHandler: saveHandler,
-                                     viewModel: RecipePickerViewModel(dataManager: .preview))
+                                     viewModel: RecipePickerViewModel())
                 } // END OF SWITCH
             } // END OF VSTACK
     } // END OF BODY


### PR DESCRIPTION
… for default value

A small PR to fix the issue with core data having problems with figuring out which model and container to use to save/retrive data. 

The issue was cause by mistakenly calling for .preview instance of data manager in running code. Instance change to shared solved the issue.
