### PR TITLE
Add nav titiles to meal plan host view

### DIFF
--- a/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MealPlanEditorView<T: MealPlanViewModelProtocol>: View {
     @ObservedObject var viewModel: T
     @Binding var navigationPath: NavigationPath
-    
+    let title: String
     var body: some View {
         List {
             
@@ -92,6 +92,7 @@ struct MealPlanEditorView<T: MealPlanViewModelProtocol>: View {
         .sheet(item: $viewModel.selectedMeal) { _ in
             MealPlanEditorSheetView(saveHandler: viewModel as MealPlanEditorSheetView.MealPlanEditorSaveHandler, navigationPath: $navigationPath)
         }
+        .navigationTitle(title)
     } // END OF BODY
     
     func generateIngredientLabel(ingredient: Ingredient) -> String {
@@ -109,7 +110,7 @@ struct MealPlanEditorView_Previews: PreviewProvider {
         @State var navigationPath = NavigationPath()
         var body: some View {
             NavigationStack {
-                MealPlanEditorView(viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan, dataManager: DataManager.preview), navigationPath: $navigationPath)
+                MealPlanEditorView(viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan, dataManager: DataManager.preview), navigationPath: $navigationPath, title: "Adding new meal plan")
             }
         }
     }

--- a/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
@@ -12,11 +12,12 @@ struct MealPlanHostView: View {
     @ObservedObject var viewModel: MealPlanViewModel
     @Binding var navigationPath: NavigationPath
     @State var isEditing: Bool = false
+    @State var isAddingNewMealPlan: Bool = false
     
     var body: some View {
         ZStack {
             if isEditing {
-                MealPlanEditorView(viewModel: viewModel, navigationPath: $navigationPath)
+                MealPlanEditorView(viewModel: viewModel, navigationPath: $navigationPath, title: provideEditingTitle())
             } else {
                 MealPlanDetailView(viewModel: viewModel)
             }
@@ -26,6 +27,7 @@ struct MealPlanHostView: View {
                     Button {
                         if isEditing == true {
                             viewModel.saveChanges()
+                            isAddingNewMealPlan = false
                         }
                         isEditing.toggle()
                     } label: {
@@ -33,6 +35,12 @@ struct MealPlanHostView: View {
                     }
                 }
             }
+    }
+    func provideEditingTitle() -> String {
+        if isAddingNewMealPlan {
+         return "Adding new meal plan"
+        }
+        return "Editing meal plan"
     }
 }
 

--- a/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 enum MealPlanTabNavigationState: Hashable {
     case showingMealPlanDetailView(MealPlan)
     case showingMealPlanEditingView(MealPlan)
+    case showingMealPlanAddingView(MealPlan)
 }
 
 struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
@@ -50,7 +51,7 @@ struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
                 .toolbar {
                     
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        NavigationLink(value: MealPlanTabNavigationState.showingMealPlanEditingView(MealPlan(meals: []))) {
+                        NavigationLink(value: MealPlanTabNavigationState.showingMealPlanAddingView(MealPlan(meals: []))) {
                             Image(systemName: "plus.circle")
                         }
                         
@@ -81,6 +82,8 @@ struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
                         MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: false)
                     case .showingMealPlanEditingView(let plan):
                         MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: true)
+                    case .showingMealPlanAddingView(let plan):
+                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: true, isAddingNewMealPlan: true)
                     }
                 }
         } // END OF NAV STACK


### PR DESCRIPTION
Meal Plan host view, editor and detail view lacked navigation title informing user what screen they are on. 

Added navigation title in EditorView, @State var informing the view if it is adding new plan and functions to handle the UI text generation. 
