### PR TITLE
Add UI testing for meal plan host view

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		D6E35C432A39EB1900CB9E19 /* RecipeCreatorHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E35C422A39EB1900CB9E19 /* RecipeCreatorHostView.swift */; };
 		D6E5695D2A4ED23400589573 /* MealPlanListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E5695C2A4ED23400589573 /* MealPlanListView.swift */; };
 		D6E5695F2A4F5F1F00589573 /* MealPlanGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E5695E2A4F5F1F00589573 /* MealPlanGridView.swift */; };
+		D6E77DDE2A686B500093DB8A /* MealPlanHostViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E77DDD2A686B500093DB8A /* MealPlanHostViewUITests.swift */; };
 		D6EC92F72A027EA800863F2D /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EC92F62A027EA800863F2D /* ViewExtensions.swift */; };
 		D6EC92FA2A027EFD00863F2D /* SizePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EC92F92A027EFD00863F2D /* SizePreferenceKey.swift */; };
 		D6EC92FC2A02F23800863F2D /* IngredientEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EC92FB2A02F23800863F2D /* IngredientEditorView.swift */; };
@@ -243,6 +244,7 @@
 		D6E35C422A39EB1900CB9E19 /* RecipeCreatorHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorHostView.swift; sourceTree = "<group>"; };
 		D6E5695C2A4ED23400589573 /* MealPlanListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlanListView.swift; sourceTree = "<group>"; };
 		D6E5695E2A4F5F1F00589573 /* MealPlanGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlanGridView.swift; sourceTree = "<group>"; };
+		D6E77DDD2A686B500093DB8A /* MealPlanHostViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlanHostViewUITests.swift; sourceTree = "<group>"; };
 		D6EC92F62A027EA800863F2D /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		D6EC92F92A027EFD00863F2D /* SizePreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizePreferenceKey.swift; sourceTree = "<group>"; };
 		D6EC92FB2A02F23800863F2D /* IngredientEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientEditorView.swift; sourceTree = "<group>"; };
@@ -355,6 +357,7 @@
 				D69684642A6420EA0064DD83 /* RecipeListUITests.swift */,
 				D661A44F2A5F4A0F005C0C5B /* RecipeCreatorUITests.swift */,
 				D63236872A66CC9400573CFF /* MealPlanTabUITests.swift */,
+				D6E77DDD2A686B500093DB8A /* MealPlanHostViewUITests.swift */,
 				D634FFA429FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift */,
 			);
 			path = GymMealPrepUITests;
@@ -855,6 +858,7 @@
 				D69684652A6420EA0064DD83 /* RecipeListUITests.swift in Sources */,
 				D661A4502A5F4A0F005C0C5B /* RecipeCreatorUITests.swift in Sources */,
 				D634FFA529FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift in Sources */,
+				D6E77DDE2A686B500093DB8A /* MealPlanHostViewUITests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,
 				D63236882A66CC9400573CFF /* MealPlanTabUITests.swift in Sources */,
 				D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */,

--- a/GymMealPrepUITests/MealPlanHostViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanHostViewUITests.swift
@@ -30,5 +30,62 @@ final class MealPlanHostViewUITests: XCTestCase {
     override func tearDown() {
         app = nil
     }
-
+    
+    func test_MealPlanHostView_isDisplayingCorrectTitle() {
+        // Given
+        let navTitle = app.navigationBars["Sample Test Plan"].staticTexts["Sample Test Plan"]
+        navigateToMealPlanDetail()
+        
+        // Then
+        let navTitleExistance = navTitle.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(navTitleExistance, "Navigation title for Sample Test Plan should exist")
+    }
+    
+    func test_MealPlanHostView_EditButton_isExisting() {
+        // Given
+        navigateToMealPlanDetail()
+        let editButton = app.navigationBars["Sample Test Plan"].buttons["Edit"]
+        
+        // Then
+        let editButtonExistance = editButton.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(editButtonExistance, "Edit button should exist")
+    }
+    
+    func test_MealPlanHostView_EditButton_isStartingEditModeOnTap() {
+        // Given
+        navigateToMealPlanDetail()
+        let editButton = app.navigationBars["Sample Test Plan"].buttons["Edit"]
+        
+        // When
+        editButton.tap()
+        
+        // Then
+        let navTitleText = app.navigationBars.staticTexts["Editing meal plan"]
+        let navTitleTextExistance = navTitleText.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(navTitleTextExistance, "Editing meal plan navigation title should exist")
+    }
+    
+    func test_MealPlanHostView_EditingButton_isChangingToDoneButtonOnTap() {
+        // Given
+        navigateToMealPlanDetail()
+        
+        // When
+        app.navigationBars["Sample Test Plan"].buttons["Edit"].tap()
+        
+        // Then
+        let doneButtonExistance = app.navigationBars["Editing meal plan"].buttons["Done"].waitForExistence(timeout: standardTimeout)
+        XCTAssert(doneButtonExistance, "Done button should exist when editing meal plan")
+        
+        
+    }
+    
+    func navigateToMealPlanTabView() {
+        app.tabBars["Tab Bar"].buttons["Meal plans"].tap()
+    }
+    
+    func navigateToMealPlanDetail() {
+        navigateToMealPlanTabView()
+        app.collectionViews.cells.buttons["Sample Test Plan, Total of 3 meals, Calories, 1845, Proteins, 103, Fats, 88, Carbs, 156"].tap()
+        
+    }
 }

--- a/GymMealPrepUITests/MealPlanHostViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanHostViewUITests.swift
@@ -1,0 +1,34 @@
+//
+//  MealPlanHostViewUITests.swift
+//  GymMealPrepUITests
+//
+//  Created by Tomasz Kubiak on 7/19/23.
+//
+
+import XCTest
+
+final class MealPlanHostViewUITests: XCTestCase {
+    
+    //MARK: INFORMATION ABOUT NAMING
+    /*
+     Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour
+     Naming structure: test_[Struct or class]_[UI component]_[expected result]
+     Testing structure: Given, When, Then
+     */
+
+    var app: XCUIApplication!
+    
+    let standardTimeout = 2.5
+    
+    override func setUp() {
+        app = XCUIApplication()
+        continueAfterFailure = false
+        app.launchArguments = ["-UITests"]
+        app.launch()
+    }
+
+    override func tearDown() {
+        app = nil
+    }
+
+}

--- a/GymMealPrepUITests/MealPlanTabUITests.swift
+++ b/GymMealPrepUITests/MealPlanTabUITests.swift
@@ -9,7 +9,6 @@ import XCTest
 
 final class MealPlanTabUITests: XCTestCase {
 
-    
     //MARK: INFORMATION ABOUT NAMING
     /*
      Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour


### PR DESCRIPTION
This PR adds UI testing for the meal plan host view. Tests are regarding appearance of the navigation title, to confirm correct navigation to views, existence and working of buttons that change between editing and detail view state of the host view. 

This UI test should provide some basis to determine whether the host view works correctly. 