### PR TITLE
14 meal plan meals order is not consistent between launches

### DIFF
--- a/GymMealPrep/CoreDataModel/MealPlanMO+CoreDataProperties.swift
+++ b/GymMealPrep/CoreDataModel/MealPlanMO+CoreDataProperties.swift
@@ -18,12 +18,30 @@ extension MealPlanMO {
 
     @NSManaged public var id: UUID
     @NSManaged public var name: String?
-    @NSManaged public var meals: NSSet?
+    @NSManaged public var meals: NSOrderedSet?
 
 }
 
 // MARK: Generated accessors for meals
 extension MealPlanMO {
+
+    @objc(insertObject:inMealsAtIndex:)
+    @NSManaged public func insertIntoMeals(_ value: MealMO, at idx: Int)
+
+    @objc(removeObjectFromMealsAtIndex:)
+    @NSManaged public func removeFromMeals(at idx: Int)
+
+    @objc(insertMeals:atIndexes:)
+    @NSManaged public func insertIntoMeals(_ values: [MealMO], at indexes: NSIndexSet)
+
+    @objc(removeMealsAtIndexes:)
+    @NSManaged public func removeFromMeals(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInMealsAtIndex:withObject:)
+    @NSManaged public func replaceMeals(at idx: Int, with value: MealMO)
+
+    @objc(replaceMealsAtIndexes:withMeals:)
+    @NSManaged public func replaceMeals(at indexes: NSIndexSet, with values: [MealMO])
 
     @objc(addMealsObject:)
     @NSManaged public func addToMeals(_ value: MealMO)
@@ -32,10 +50,10 @@ extension MealPlanMO {
     @NSManaged public func removeFromMeals(_ value: MealMO)
 
     @objc(addMeals:)
-    @NSManaged public func addToMeals(_ values: NSSet)
+    @NSManaged public func addToMeals(_ values: NSOrderedSet)
 
     @objc(removeMeals:)
-    @NSManaged public func removeFromMeals(_ values: NSSet)
+    @NSManaged public func removeFromMeals(_ values: NSOrderedSet)
 
 }
 

--- a/GymMealPrep/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/GymMealPrep/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -32,7 +32,7 @@
     <entity name="MealPlanMO" representedClassName="MealPlanMO" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <relationship name="meals" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MealMO" inverseName="plan" inverseEntity="MealMO"/>
+        <relationship name="meals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MealMO" inverseName="plan" inverseEntity="MealMO"/>
     </entity>
     <entity name="RecipeMO" representedClassName="RecipeMO" syncable="YES">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>

--- a/GymMealPrep/Model/MealPlan.swift
+++ b/GymMealPrep/Model/MealPlan.swift
@@ -26,7 +26,7 @@ struct MealPlan: Identifiable, Hashable {
         self.id = mealPlanMO.id
         self.name = mealPlanMO.name
         if let mealsMO = mealPlanMO.meals {
-            self.meals = mealsMO.allObjects.compactMap({ $0 as? MealMO }).map({ Meal(mealMO: $0)})
+            self.meals = mealsMO.array.compactMap({ $0 as? MealMO}).map({ Meal(mealMO: $0)})
         } else {
             self.meals = []
         }


### PR DESCRIPTION
Meals showed in meal plan are not consistently ordered between launches. This is caused by the data not being ordered. This PR changes the data from NSSet to NSOrderedSet, therefore providing a consistent ordered for the meals objects in MealPlan. 
