### PR TITLE
18 mealplaneditorview does not have a way to delete a meal from plan

### DIFF
--- a/GymMealPrep/MealPlan/ViewModels/MealPlanViewModel.swift
+++ b/GymMealPrep/MealPlan/ViewModels/MealPlanViewModel.swift
@@ -21,6 +21,8 @@ protocol MealPlanViewModelProtocol: ObservableObject, RecipeSaveHandler, Ingredi
     func addIngredient(_: Ingredient, _: String?)
     
     func addMeal()
+    
+    func deleteMeal(_: Meal)
 }
 
 class MealPlanViewModel: MealPlanViewModelProtocol {
@@ -77,5 +79,9 @@ class MealPlanViewModel: MealPlanViewModelProtocol {
     
     func updateMealPlan() {
         mealPlan.name = mealPlanName
+    }
+    
+    func deleteMeal(_ meal: Meal) {
+        mealPlan.meals.removeAll(where: { $0.id == meal.id})
     }
 }

--- a/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
@@ -117,7 +117,16 @@ extension MealPlanEditorView {
             }
             
         } header: {
+            HStack{
                 Text("Meal #\(index + 1)")
+                Spacer()
+                Button {
+                    viewModel.deleteMeal(meal)
+                } label: {
+                    Label("Delete meal", systemImage: "trash.circle.fill")
+                        .foregroundColor(.red)
+                }
+            }
         } // END OF HEADER
         .headerProminence(.increased)
     }

--- a/GymMealPrepUITests/MealPlanEditorViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanEditorViewUITests.swift
@@ -144,7 +144,7 @@ final class MealPlanEditorViewUITests: XCTestCase {
         XCTAssertTrue(result, "Recipe row should not exist")
     }
     
-    func test_mealPlanEditorView_ingredientRowDeleteButtonPressed_shoulRemoveRecipeRow() {
+    func test_mealPlanEditorView_ingredientRowDeleteButtonPressed_shoulRemoveIngredientRow() {
         // Given
         navigateToEdit()
         let ingredientRow = app.collectionViews.cells.staticTexts["Rice 50.0 grams"]
@@ -181,6 +181,23 @@ final class MealPlanEditorViewUITests: XCTestCase {
         XCTAssertTrue(result, "Meal #4 should exist")
     }
     
+    func test_MealPlanEditorView_DeleteMealButtonPressed_shouldDeleteMeal() {
+        // Given
+        navigateToEdit()
+        let deleteMealButton = app.collectionViews.buttons["Delete meal"].firstMatch
+        // since meal #1 will be assigned to first meal item on list, checking on recipe in starting meal #1
+        let meal1RecipeStaticText = app.collectionViews.cells.staticTexts["Breakfast potato hash"]
+        
+        // When
+        deleteMealButton.tap()
+        
+        // Then
+        let result = meal1RecipeStaticText.waitForNonExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "'Breakfast potato hash' static text should not exit")
+    }
+}
+
+extension MealPlanEditorViewUITests {
     func navigateToEdit() {
         app.tabBars["Tab Bar"].buttons["Meal plans"].tap()
         app.collectionViews.cells.buttons["Sample Test Plan, Total of 3 meals, Calories, 1845, Proteins, 103, Fats, 88, Carbs, 156"].tap()


### PR DESCRIPTION
This PR brings the missing feature to the meal plan editor.

Previously, the user did not have an option to delete an existing meal in a given meal plan. To reduce the number of meal, user would have to create a new meal plan and fill it up again. This is of course not great. 

In the PR view builder func responsible for creating meal sections in editor got an addition of "Delete meal" button. Relevant protocol and implementations got updated and additional UI test were written.