### PR TITLE
17 mealplanview not updating changes immediately after done tapped

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -68,7 +68,7 @@
 		D694E4072A05824A0077E72F /* IngredientMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3FB2A05824A0077E72F /* IngredientMO+CoreDataClass.swift */; };
 		D694E4082A05824A0077E72F /* IngredientMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */; };
 		D694E40D2A05824A0077E72F /* TagMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */; };
-		D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */; };
+		D69684632A641C9F0064DD83 /* XCUIElement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684622A641C9F0064DD83 /* XCUIElement+Extensions.swift */; };
 		D69684652A6420EA0064DD83 /* RecipeListUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69684642A6420EA0064DD83 /* RecipeListUITests.swift */; };
 		D69B9DC32A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */; };
 		D69B9DC52A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */; };
@@ -202,7 +202,7 @@
 		D694E3FB2A05824A0077E72F /* IngredientMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IngredientMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D694E3FC2A05824A0077E72F /* IngredientMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IngredientMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D694E4012A05824A0077E72F /* TagMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagMO+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Existance.swift"; sourceTree = "<group>"; };
+		D69684622A641C9F0064DD83 /* XCUIElement+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Extensions.swift"; sourceTree = "<group>"; };
 		D69684642A6420EA0064DD83 /* RecipeListUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecipeListUITests.swift; path = GymMealPrepUITests/RecipeListUITests.swift; sourceTree = SOURCE_ROOT; };
 		D69B9DC22A2F593E00A4FB08 /* RecipeCreatorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorViewModelTests.swift; sourceTree = "<group>"; };
 		D69B9DC42A2FB44300A4FB08 /* RecipeCreatorInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorInstructionsView.swift; sourceTree = "<group>"; };
@@ -588,7 +588,7 @@
 			isa = PBXGroup;
 			children = (
 				D6C7A2B92A63F0E400A82757 /* XCT+Focus.swift */,
-				D69684622A641C9F0064DD83 /* XCUIElement+Existance.swift */,
+				D69684622A641C9F0064DD83 /* XCUIElement+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -865,7 +865,7 @@
 				D6AD53862A699DF20091306B /* MealPlanEditorViewUITests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,
 				D63236882A66CC9400573CFF /* MealPlanTabUITests.swift in Sources */,
-				D69684632A641C9F0064DD83 /* XCUIElement+Existance.swift in Sources */,
+				D69684632A641C9F0064DD83 /* XCUIElement+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GymMealPrep/MealPlan/ViewModels/MealPlanTabViewModel.swift
+++ b/GymMealPrep/MealPlan/ViewModels/MealPlanTabViewModel.swift
@@ -14,9 +14,6 @@ protocol MealPlanTabViewModelProtocol: ObservableObject {
     
     func deleteMealPlan(_: MealPlan)
     
-    associatedtype T: MealPlanViewModelProtocol
-    func createMealPlanViewModel(for: MealPlan) -> T
-    
 }
 
 class MealPlanTabViewModel: MealPlanTabViewModelProtocol {
@@ -38,10 +35,6 @@ class MealPlanTabViewModel: MealPlanTabViewModelProtocol {
     
     func deleteMealPlan(_ mealPlan: MealPlan) {
         //TODO: IMPLEMENT DELETE FUNCTION
-    }
-    
-    func createMealPlanViewModel(for mealPlan: MealPlan) -> some MealPlanViewModelProtocol {
-        return MealPlanViewModel(mealPlan: mealPlan, dataManager: dataManager as MealPlanDataManagerProtocol)
     }
 }
 

--- a/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
@@ -44,7 +44,7 @@ extension MealPlanEditorView {
             
             TextField("Meal plan name", text: $viewModel.mealPlanName)
                 .textFieldStyle(.roundedBorder)
-            
+                .accessibilityIdentifier("meal-plan-title-textfield")
             RecipeSummaryView(
                 cal: viewModel.mealPlan.nutrition.calories,
                 proteinInGrams: viewModel.mealPlan.nutrition.protein,

--- a/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
@@ -8,11 +8,17 @@
 import SwiftUI
 
 struct MealPlanHostView: View {
-    
-    @ObservedObject var viewModel: MealPlanViewModel
+    @StateObject var viewModel: MealPlanViewModel
     @Binding var navigationPath: NavigationPath
     @State var isEditing: Bool = false
-    @State var isAddingNewMealPlan: Bool = false
+    @State var isAddingNewMealPlan: Bool = false  
+    
+    init(viewModel: MealPlanViewModel, navigationPath: Binding<NavigationPath>, isEditing: Bool = false, isAddingNewMealPlan: Bool = false) {
+        self._viewModel = StateObject.init(wrappedValue: viewModel)
+        self._navigationPath = navigationPath
+        self.isEditing = isEditing
+        self.isAddingNewMealPlan = isAddingNewMealPlan
+    }
     
     var body: some View {
         ZStack {

--- a/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
@@ -113,10 +113,6 @@ struct MealPlanTabView_Previews: PreviewProvider {
             })
         }
         
-        func createMealPlanViewModel(for: MealPlan) -> some MealPlanViewModelProtocol {
-            MealPlanViewModel(mealPlan: mealPlanArray[0],
-                                dataManager: DataManager.preview as MealPlanDataManagerProtocol)
-        }
         init() {
             self.mealPlanArray = []
             for i in 0..<10 {

--- a/GymMealPrepUITests/Extensions/XCUIElement+Extensions.swift
+++ b/GymMealPrepUITests/Extensions/XCUIElement+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  XCUIElement+Existance.swift
+//  XCUIElement+Extensions.swift
 //  GymMealPrepUITests
 //
 //  Created by Tomasz Kubiak on 7/16/23.

--- a/GymMealPrepUITests/Extensions/XCUIElement+Extensions.swift
+++ b/GymMealPrepUITests/Extensions/XCUIElement+Extensions.swift
@@ -9,10 +9,23 @@ import Foundation
 import XCTest
 
 extension XCUIElement {
+    
     func waitForNonExistence(timeout: TimeInterval) -> Bool {
         let predicate = NSPredicate(format: "exists == false")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
         _ = XCTWaiter.wait(for: [expectation], timeout: timeout)
         return !exists
+    }
+    
+    func clearAndTypeText(_ text: String) {
+        guard let stringValue = self.value as? String else { return }
+        
+        var deleteString = String()
+        for _ in stringValue {
+            deleteString += XCUIKeyboardKey.delete.rawValue
+        }
+        
+        self.typeText(deleteString)
+        self.typeText(text)
     }
 }

--- a/GymMealPrepUITests/MealPlanHostViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanHostViewUITests.swift
@@ -75,9 +75,26 @@ final class MealPlanHostViewUITests: XCTestCase {
         // Then
         let doneButtonExistance = app.navigationBars["Editing meal plan"].buttons["Done"].waitForExistence(timeout: standardTimeout)
         XCTAssert(doneButtonExistance, "Done button should exist when editing meal plan")
-        
-        
     }
+    
+    func test_MealPlanHostView_DetailView_isUpdatingAfterEdit() {
+        // Given
+        navigateToMealPlanEditor()
+        let deleteMealButton = app.collectionViews.buttons["Delete meal"].firstMatch
+        let doneButton = app.navigationBars.buttons["Done"]
+        let meal1RecipeStaticText = app.collectionViews.cells.staticTexts["Breakfast potato hash"]
+        
+        // When
+        deleteMealButton.tap()
+        doneButton.tap()
+        
+        // Then
+        let result = meal1RecipeStaticText.waitForNonExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Text 'Breakfast potato hash' should not exist")
+    }
+}
+
+extension MealPlanHostViewUITests {
     
     func navigateToMealPlanTabView() {
         app.tabBars["Tab Bar"].buttons["Meal plans"].tap()
@@ -86,6 +103,10 @@ final class MealPlanHostViewUITests: XCTestCase {
     func navigateToMealPlanDetail() {
         navigateToMealPlanTabView()
         app.collectionViews.cells.buttons["Sample Test Plan, Total of 3 meals, Calories, 1845, Proteins, 103, Fats, 88, Carbs, 156"].tap()
-        
+    }
+    
+    func navigateToMealPlanEditor() {
+        navigateToMealPlanDetail()
+        app.navigationBars.buttons["Edit"].tap()
     }
 }

--- a/GymMealPrepUITests/MealPlanHostViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanHostViewUITests.swift
@@ -92,6 +92,25 @@ final class MealPlanHostViewUITests: XCTestCase {
         let result = meal1RecipeStaticText.waitForNonExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Text 'Breakfast potato hash' should not exist")
     }
+    
+    func test_MealPlanHostView_DetailView_isUpdatingNameAfterEdit() {
+        // Given
+        navigateToMealPlanEditor()
+        let titleTextField = app.collectionViews.textFields["meal-plan-title-textfield"]
+        let doneButton = app.navigationBars.buttons["Done"]
+        let navigationTitle = app.navigationBars.staticTexts["Changed meal plan name"]
+        let changedMealPlanName = "Changed meal plan name"
+        
+        // When
+        titleTextField.tap()
+        titleTextField.clearAndTypeText(changedMealPlanName)
+//        titleTextField.typeText(changedMealPlanName)
+        doneButton.tap()
+        
+        // Then
+        let result = navigationTitle.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Navigation titile 'Changed meal plan' should exist")
+    }
 }
 
 extension MealPlanHostViewUITests {

--- a/GymMealPrepUITests/MealPlanHostViewUITests.swift
+++ b/GymMealPrepUITests/MealPlanHostViewUITests.swift
@@ -77,7 +77,7 @@ final class MealPlanHostViewUITests: XCTestCase {
         XCTAssert(doneButtonExistance, "Done button should exist when editing meal plan")
     }
     
-    func test_MealPlanHostView_DetailView_isUpdatingAfterEdit() {
+    func test_MealPlanHostView_DetailView_isUpdatingMealsAfterEdit() {
         // Given
         navigateToMealPlanEditor()
         let deleteMealButton = app.collectionViews.buttons["Delete meal"].firstMatch


### PR DESCRIPTION
Why:
This PR is solving the problem from issue 17. This issue points to problem that detail view is not updated after tapping "Done" button. The user needs to reload the view by going back to list of all of the meal plans. The problem was traced back to lack of ownership of the view model for the MealPlanHostView. 

What was done: 
- The observed object in host view was changed to state object. 
- Custom init was added
- UI test for deleting a meal, navigating to detail view and confirming change propagated was added 
- UI test for changing a name of the meal plan, navigating to detail view and confirming change propagated was added 
- Additional XCUI Element extension was added that allows for clearing text in text field and typing in additional text was added 