### PR TITLE
26 photopicker not working in recipe creator

### DIFF
--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
@@ -36,6 +36,7 @@ struct RecipeCreatorConfirmationView: View {
                             } label: {
                                 Text("Delete")
                             } // END OF BUTTON
+                            .accessibilityIdentifier("delete-photo")
                             .buttonStyle(.borderedProminent)
                         } // END OF IF
                         Spacer()

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
@@ -27,12 +27,9 @@ struct RecipeCreatorConfirmationView: View {
                         Spacer()
                         PhotosPicker(selection: $viewModel.selectedImage){
                             Text(viewModel.recipeImage == nil ? "Add photo" : "Change photo")
-                                .foregroundColor(.white)
-                                .padding(.all, 8)
-                                .background(Color.blue)
-                                .cornerRadius(4)
                                 .accessibilityIdentifier("add-change-photo")
                         } // END OF PHOTOSPICKER
+                        .buttonStyle(.borderedProminent)
                         if viewModel.recipeImage != nil {
                             Button(role: .destructive) {
                                 viewModel.recipeImage = nil

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct RecipeCreatorConfirmationView: View {
     @ObservedObject var viewModel: RecipeCreatorViewModelProtocol
@@ -15,17 +16,35 @@ struct RecipeCreatorConfirmationView: View {
         List {
             
             Section("Photo") {
-                Button {
-                    //TODO: MISSING IMPLEMENTATION OF ADDING PHOTO
-                    print("Adding photo")
-                } label: {
-                    Image(systemName: "photo")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .padding(.horizontal, 50)
-                }
-                .accessibilityIdentifier("add-change-photo")
-            }
+                    if let image = viewModel.recipeImage {
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(height: 250)
+                            .listRowInsets(EdgeInsets())
+                    } // END OF IMAGE
+                    HStack {
+                        Spacer()
+                        PhotosPicker(selection: $viewModel.selectedImage){
+                            Text(viewModel.recipeImage == nil ? "Add photo" : "Change photo")
+                                .foregroundColor(.white)
+                                .padding(.all, 8)
+                                .background(Color.blue)
+                                .cornerRadius(4)
+                                .accessibilityIdentifier("add-change-photo")
+                        } // END OF PHOTOSPICKER
+                        if viewModel.recipeImage != nil {
+                            Button(role: .destructive) {
+                                viewModel.recipeImage = nil
+                            } label: {
+                                Text("Delete")
+                            } // END OF BUTTON
+                            .buttonStyle(.borderedProminent)
+                        } // END OF IF
+                        Spacer()
+                    } // END OF HSTACK
+                } // END OF SECTION
+            
             
             Section("Time cooking") {
                 Grid(alignment: .leading) {
@@ -95,6 +114,22 @@ struct RecipeCreatorConfirmationView: View {
 struct RecipeCreatorConfirmationView_Previews: PreviewProvider {
     
     class PreviewViewModel: RecipeCreatorViewModelProtocol {
+        
+        override var selectedImage: PhotosPickerItem? {
+            didSet {
+                if let selectedImage {
+                    Task { @MainActor in
+                        do {
+                            recipeImage = try await selectedImage.loadTransferable(type: Image.self) ?? Image(systemName: "photo")
+                            //try await loadTransferable(from: selectedImage)
+                        } catch {
+                            print("Error loading photo: \(error.localizedDescription)")
+                        }
+                    }
+                }
+            }
+        }
+        
         override init() {
             super.init()
             self.tags = [

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
@@ -32,7 +32,7 @@ struct RecipeCreatorConfirmationView: View {
                         .buttonStyle(.borderedProminent)
                         if viewModel.recipeImage != nil {
                             Button(role: .destructive) {
-                                viewModel.recipeImage = nil
+                                viewModel.deletePhoto()
                             } label: {
                                 Text("Delete")
                             } // END OF BUTTON
@@ -119,13 +119,16 @@ struct RecipeCreatorConfirmationView_Previews: PreviewProvider {
                     Task { @MainActor in
                         do {
                             recipeImage = try await selectedImage.loadTransferable(type: Image.self) ?? Image(systemName: "photo")
-                            //try await loadTransferable(from: selectedImage)
                         } catch {
                             print("Error loading photo: \(error.localizedDescription)")
                         }
                     }
                 }
             }
+        }
+        
+        override func deletePhoto() {
+            recipeImage = nil
         }
         
         override init() {

--- a/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import Combine
+import PhotosUI
+import SwiftUI
 
 /// This class is a protocol definition for view model of RecipeCreatorViews
 class RecipeCreatorViewModelProtocol: ObservableObject, IngredientSaveHandler {
@@ -21,6 +23,8 @@ class RecipeCreatorViewModelProtocol: ObservableObject, IngredientSaveHandler {
     @Published var timeWaitingInMinutes: String = String()
     @Published var tagText: String = String()
     @Published var servings: Int = 1
+    // image input
+    @Published var selectedImage: PhotosPickerItem?
     // input processed properties
     @Published var ingredientsNLArray: [String] = []
     var instructionsNLArray: [String] = []
@@ -30,6 +34,7 @@ class RecipeCreatorViewModelProtocol: ObservableObject, IngredientSaveHandler {
     @Published var matchedIngredients = [String : Ingredient]()
     @Published var parsedInstructions: [Instruction] = []
     @Published var tags: [Tag] = []
+    @Published var recipeImage: Image?
     
     func processInput() {
         assertionFailure("Missing override: Please override this method in the subclass")
@@ -66,6 +71,18 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
     private var dataManager: DataManager
     var subscriptions = Set<AnyCancellable>()
     let edamamLogicController: EdamamLogicControllerProtocol = EdamamLogicController(networkController: NetworkController())
+    
+    override var selectedImage: PhotosPickerItem? {
+        didSet {
+                Task { @MainActor in
+                    do {
+                        recipeImage = try await selectedImage?.loadTransferable(type: Image.self)
+                    } catch {
+                        print("Error loading photo: \(error.localizedDescription)")
+                    }
+                }
+        }
+    }
     
     init(dataManager: DataManager = .shared) {
         self.dataManager = dataManager

--- a/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
@@ -64,7 +64,9 @@ class RecipeCreatorViewModelProtocol: ObservableObject, IngredientSaveHandler {
     func addInstruction() {
         assertionFailure("Missing override: Please override this method in the subclass")
     }
-    
+    func deletePhoto() {
+        assertionFailure("Missing override: Please override this method in the subclass")
+    }
 }
 
 class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
@@ -107,7 +107,7 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
         let result = tag.waitForNonExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "'Test tag' static test should not exist")
     }
-    // Confirm photo part works
+    
     func test_RecipeCreatorConfirmationView_AddPhotoButton_displaysPhotoPicker() {
         // Given
         navigateToRecipeCreatorConfirmationView()
@@ -119,7 +119,63 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
         XCTAssertTrue(result, "A 'Photos' navigation bar should exists after tap")
     }
     
-    // Confirm text fields work
+    func test_RecipeCreatorConfirmationView_RecipeImageUpdatedAfterPhotoIsPicked() {
+        // Given
+        let photoId = "Photo, August 08, 2012, 11:29 PM"
+        navigateToRecipeCreatorConfirmationView()
+        app.collectionViews.buttons["add-change-photo"].tap()
+        // When
+        app.scrollViews.images[photoId].tap()
+        // Then
+        // photo does not have id?
+        let result = app.collectionViews.descendants(matching: .image).firstMatch.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Photo '\(photoId)' should exist")
+    }
+    
+    func test_RecipeCreatorConfirmationView_AddPhotoButton_changesLabel_whenPhotoIsLoaded() {
+        // Given
+        let photoId = "Photo, August 08, 2012, 11:29 PM"
+        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
+        navigateToRecipeCreatorConfirmationView()
+        addPhotoButton.tap()
+        // When
+        app.scrollViews.images[photoId].tap()
+        // Then
+        XCTAssertEqual(addPhotoButton.label, "Change photo", "'add-change-photo' button should have value 'Change photo")
+    }
+    
+    func test_RecipeCreatorConfirmationView_DeleteButton_exists_whenPhotoIsLoaded() {
+        // Given
+        let photoId = "Photo, August 08, 2012, 11:29 PM"
+        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
+        let deletePhotoButton = app.collectionViews.buttons["delete-photo"]
+        navigateToRecipeCreatorConfirmationView()
+        addPhotoButton.tap()
+        // When
+        app.scrollViews.images[photoId].tap()
+        // Then
+        let expectations = [expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: deletePhotoButton)]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Delete photo button should exist")
+    }
+    
+    func test_RecipeCreatorConfirmationView_DeleteButton_removesPhotoAndItself_whenTaped() {
+        // Given
+        let deletePhotoButton = app.collectionViews.buttons["delete-photo"]
+        let photoId = "Photo, August 08, 2012, 11:29 PM"
+        navigateToRecipeCreatorConfirmationView()
+        app.collectionViews.buttons["add-change-photo"].tap()
+        app.scrollViews.images[photoId].tap()
+        // When
+        deletePhotoButton.tap()
+        // Then
+        let predicate = NSPredicate(format: "exists == false")
+        let expectations = [expectation(for: predicate, evaluatedWith: deletePhotoButton),
+        expectation(for: predicate, evaluatedWith: app.collectionViews.descendants(matching: .image).firstMatch)]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Photo '\(photoId)' and delete button should not exist")
+    }
+
     func test_RecipeCreatorConfirmationView_TimeTextFields_areEditable() {
         // Given
         navigateToRecipeCreatorConfirmationView()

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
@@ -159,6 +159,25 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
         XCTAssertEqual(result, .completed, "Delete photo button should exist")
     }
     
+    // TOMASZ: FOR THIS TEST TO OPERATE ASSET ID HAS TO BE OBTAINED FROM PHOTO PICKER
+    /*
+    func test_RecipeCreatorConfirmationView_ChangePhotoButton_changesPhotoOnTap() {
+        // Given
+        let firstPhotoId = "Photo, August 08, 2012, 11:29 PM"
+        let secondPhotoId = "Photo, Augus 08, 2012, 11:55 PM"
+        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
+        navigateToRecipeCreatorConfirmationView()
+        addPhotoButton.tap()
+        firstPhotoId.tap()
+        
+        // When
+        addPhotoButton.tap()
+        secondPhotoId.tap()
+        // Then
+        let result = app.collectionViews.images[secondPhotoId].waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Image with second photo id should be present")
+    }
+    */
     func test_RecipeCreatorConfirmationView_DeleteButton_removesPhotoAndItself_whenTaped() {
         // Given
         let deletePhotoButton = app.collectionViews.buttons["delete-photo"]

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
@@ -115,8 +115,8 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
         // When
         addPhotoButton.tap()
         // Then
-        let result = app.sheets.firstMatch.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(result, "A sheet should exists after tap")
+        let result = app.navigationBars["Photos"].waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "A 'Photos' navigation bar should exists after tap")
     }
     
     // Confirm text fields work


### PR DESCRIPTION
The issue 26 identifies problem with confirmation view in recipe creator view not working. After short investigation there was no implementation for photo picker. 

This PR brings the feature of adding photos to recipe directly in recipe creator ("Add recipe from text"):
- Add image representing the image chosen for recipe 
- Add logic to change button label ("Add photo" & "Change photo")
- Add logic to show "Delete" button 
- Implement saving the chosen photo to recipe on recipe save 
- Add testing for photo features in UI tests

What could be improved: 
Currently there is no accessibility features for the image shown in the ui itself. A future improvement would bring the whole confirmation view to a state where it is accessible. 