### PR TITLE
Add e2e recipe creator uitest

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D600A38C2A7AD2F500495CE3 /* RecipeCreatorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D600A38B2A7AD2F500495CE3 /* RecipeCreatorUITests.swift */; };
 		D60598702A37B2D000186F7F /* RecipeListTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D605986F2A37B2D000186F7F /* RecipeListTabView.swift */; };
 		D605F0EF2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D605F0EE2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift */; };
 		D614A0422A1D4FA700C55D34 /* IngredientEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D614A0412A1D4FA700C55D34 /* IngredientEditorViewModel.swift */; };
@@ -83,7 +84,7 @@
 		D6A313EE2A4A06D500D5DCC2 /* DataManager+MealMOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A313ED2A4A06D500D5DCC2 /* DataManager+MealMOTests.swift */; };
 		D6A92C122A729BCA00DB4DEF /* RecipePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C112A729BCA00DB4DEF /* RecipePickerViewModel.swift */; };
 		D6A92C142A72A40D00DB4DEF /* IngredientHostViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C132A72A40D00DB4DEF /* IngredientHostViewUITests.swift */; };
-		D6A92C172A72C83A00DB4DEF /* RecipeCreatorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C162A72C83A00DB4DEF /* RecipeCreatorUITests.swift */; };
+		D6A92C172A72C83A00DB4DEF /* RecipeCreatorViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C162A72C83A00DB4DEF /* RecipeCreatorViewUITests.swift */; };
 		D6A92C192A72C85000DB4DEF /* RecipeCreatorParserViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C182A72C85000DB4DEF /* RecipeCreatorParserViewUITests.swift */; };
 		D6A92C1B2A72C85C00DB4DEF /* RecipeCreatorInstructionsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C1A2A72C85C00DB4DEF /* RecipeCreatorInstructionsViewUITests.swift */; };
 		D6A92C1D2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A92C1C2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift */; };
@@ -143,6 +144,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D600A38B2A7AD2F500495CE3 /* RecipeCreatorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorUITests.swift; sourceTree = "<group>"; };
 		D605986F2A37B2D000186F7F /* RecipeListTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeListTabView.swift; sourceTree = "<group>"; };
 		D605F0EE2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeViewModelTests.swift; sourceTree = "<group>"; };
 		D614A0412A1D4FA700C55D34 /* IngredientEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientEditorViewModel.swift; sourceTree = "<group>"; };
@@ -223,7 +225,7 @@
 		D6A313ED2A4A06D500D5DCC2 /* DataManager+MealMOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+MealMOTests.swift"; sourceTree = "<group>"; };
 		D6A92C112A729BCA00DB4DEF /* RecipePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipePickerViewModel.swift; sourceTree = "<group>"; };
 		D6A92C132A72A40D00DB4DEF /* IngredientHostViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientHostViewUITests.swift; sourceTree = "<group>"; };
-		D6A92C162A72C83A00DB4DEF /* RecipeCreatorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorUITests.swift; sourceTree = "<group>"; };
+		D6A92C162A72C83A00DB4DEF /* RecipeCreatorViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorViewUITests.swift; sourceTree = "<group>"; };
 		D6A92C182A72C85000DB4DEF /* RecipeCreatorParserViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorParserViewUITests.swift; sourceTree = "<group>"; };
 		D6A92C1A2A72C85C00DB4DEF /* RecipeCreatorInstructionsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorInstructionsViewUITests.swift; sourceTree = "<group>"; };
 		D6A92C1C2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorConfirmationViewUITests.swift; sourceTree = "<group>"; };
@@ -564,10 +566,11 @@
 			isa = PBXGroup;
 			children = (
 				D661A44F2A5F4A0F005C0C5B /* RecipeCreatorHostViewUITests.swift */,
-				D6A92C162A72C83A00DB4DEF /* RecipeCreatorUITests.swift */,
+				D6A92C162A72C83A00DB4DEF /* RecipeCreatorViewUITests.swift */,
 				D6A92C182A72C85000DB4DEF /* RecipeCreatorParserViewUITests.swift */,
 				D6A92C1A2A72C85C00DB4DEF /* RecipeCreatorInstructionsViewUITests.swift */,
 				D6A92C1C2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift */,
+				D600A38B2A7AD2F500495CE3 /* RecipeCreatorUITests.swift */,
 			);
 			path = RecipeCreatorUITests;
 			sourceTree = "<group>";
@@ -888,10 +891,11 @@
 				D6C7A2BA2A63F0E400A82757 /* XCT+Focus.swift in Sources */,
 				D69684652A6420EA0064DD83 /* RecipeListUITests.swift in Sources */,
 				D661A4502A5F4A0F005C0C5B /* RecipeCreatorHostViewUITests.swift in Sources */,
-				D6A92C172A72C83A00DB4DEF /* RecipeCreatorUITests.swift in Sources */,
+				D6A92C172A72C83A00DB4DEF /* RecipeCreatorViewUITests.swift in Sources */,
 				D634FFA529FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift in Sources */,
 				D6E77DDE2A686B500093DB8A /* MealPlanHostViewUITests.swift in Sources */,
 				D6A92C142A72A40D00DB4DEF /* IngredientHostViewUITests.swift in Sources */,
+				D600A38C2A7AD2F500495CE3 /* RecipeCreatorUITests.swift in Sources */,
 				D6AD53862A699DF20091306B /* MealPlanEditorViewUITests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,
 				D6A92C1D2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift in Sources */,

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
@@ -9,33 +9,140 @@ import XCTest
 
 final class RecipeCreatorUITests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    
+    //MARK: INFORMATION ABOUT NAMING
+    /*
+     Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour
+     Naming structure: test_[Struct or class]_[UI component]_[expected result]
+     Testing structure: Given, When, Then
+     */
 
-        // In UI tests it is usually best to stop immediately when a failure occurs.
+    var app: XCUIApplication!
+    
+    //MARK: static input properties
+    
+    let standardTimeout = 2.5
+    
+    override func setUp() {
+        app = XCUIApplication()
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
+        app.launchArguments = ["-UITests"]
         app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
+    override func tearDown() {
+        app = nil
+    }
+    
+    func test_RecipeCreator_UserAddingRecipeFromText() {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        enterData()
+        advanceStage()
+        advanceStage()
+        advanceStage()
+        addPhoto()
+        typeInCookingTimes()
+        addTags(tagsText: tagsInput())
+        // When
+        saveAndOpen()
+        // Then
+        checkInputDataOnRecipeDetailView()
+    }
+}
+
+extension RecipeCreatorUITests {
+    func checkInputDataOnRecipeDetailView() {
+        XCTAssert(false)
+    }
+    func typeInCookingTimes() {
+        let cookingTimeTextField = app.collectionViews.textFields["cooking-time-text-field"]
+        let preparingTimeTextField = app.collectionViews.textFields["preparing-time-text-field"]
+        let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
+        
+        cookingTimeTextField.tap()
+        waitUtilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
+        preparingTimeTextField.tap()
+        waitUtilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("10")
+        waitingTimeTextField.tap()
+        waitUtilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("0")
+    }
+    
+    func saveAndOpen() {
+        app.staticTexts["Save and open"].tap()
+    }
+    
+    func addTags(tagsText: [String]) {
+        for text in tagsText {
+            addTag(text: text)
         }
+        app.keyboards.buttons["Return"].tap()
+        
+    }
+    func addTag(text: String) {
+        let tagTextField = app.collectionViews.cells.textFields["Add new tag"]
+        tagTextField.tap()
+        waitUtilElementHasKeyboardFocus(element: tagTextField, timeout: standardTimeout).typeText(text)
+        app.collectionViews.cells.buttons["Add"].tap()
+    }
+    func addPhoto() {
+        app.collectionViews.buttons["add-change-photo"].tap()
+        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
+    }
+    func navigateToRecipeCreatorView() {
+        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
+        let recipiesNavigationBar = app.navigationBars["Recipes"]
+        recipiesNavigationBar.images["Back"].tap()
+        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
+        recipiesNavigationBar.buttons["Add from text"].tap()
+    }
+    
+    func tapToolTips() {
+        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
+        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
+        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        ingredientsToolTipTextView.tap()
+        instructionToolTipTextView.tap()
+    }
+    
+    func enterData() {
+        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
+        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
+        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
+        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
+        
+        titleTextField.tap()
+        titleTextField.typeText(recipeTitleInput())
+        
+        nextButton.tap()
+        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
+        
+        nextButton.tap()
+        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
+        
+        finishButton.tap()
+    }
+    
+    func advanceStage() {
+        app.staticTexts["advance-stage-button"].tap()
+    }
+    
+    func recipeTitleInput() -> String {
+        return "Breakfast burrito"
+    }
+    
+    func ingredientsInput() -> String {
+        return "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper"
+    }
+    
+    func instructionsInput() -> String {
+        return "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"
+    }
+    
+    func tagsInput() -> [String] {
+        ["breakfast", "mexican", "burrito", "freezer-friendly"]
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
@@ -48,13 +48,37 @@ final class RecipeCreatorUITests: XCTestCase {
         // When
         saveAndOpen()
         // Then
-        checkInputDataOnRecipeDetailView()
+        let expectations = checkInputDataOnRecipeDetailView()
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Basic elements should exist")
     }
 }
 
 extension RecipeCreatorUITests {
-    func checkInputDataOnRecipeDetailView() {
-        XCTAssert(false)
+    func checkInputDataOnRecipeDetailView() -> [XCTestExpectation]{
+        let recipeImage = app.collectionViews.images.firstMatch
+        let recipeTitle = app.collectionViews.cells.staticTexts[recipeTitleInput()]
+        let tagStaticTexts: [XCUIElement] = {
+           var array = [XCUIElement]()
+            for text in tagsInput() {
+                let staticText = app.collectionViews.staticTexts[text]
+                array.append(staticText)
+            }
+            return array
+        }()
+        let elementsToEvaluate: [XCUIElement] = {
+            var array = [XCUIElement]()
+            array.append(recipeImage)
+            array.append(recipeTitle)
+            array.append(contentsOf: tagStaticTexts)
+            return array
+        }()
+        let predicate = NSPredicate(format: "exists == true")
+        var expectations = [XCTestExpectation]()
+        for element in elementsToEvaluate {
+            expectations.append( expectation(for: predicate, evaluatedWith: element))
+        }
+        return expectations
     }
     func typeInCookingTimes() {
         let cookingTimeTextField = app.collectionViews.textFields["cooking-time-text-field"]

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
@@ -1,221 +1,41 @@
 //
-//  RecipeCreatorUITests.swift
+//  RecipeCreatorUserWorkflowUITests.swift
 //  GymMealPrepUITests
 //
-//  Created by Tomasz Kubiak on 7/27/23.
+//  Created by Tomasz Kubiak on 8/2/23.
 //
 
 import XCTest
 
 final class RecipeCreatorUITests: XCTestCase {
 
-    //MARK: INFORMATION ABOUT NAMING
-    /*
-     Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour
-     Naming structure: test_[Struct or class]_[UI component]_[expected result]
-     Testing structure: Given, When, Then
-     */
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
 
-    var app: XCUIApplication!
-    
-    
-    let standardTimeout = 2.5
-    
-    override func setUp() {
-        app = XCUIApplication()
+        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-        app.launchArguments = ["-UITests"]
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
         app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
-    override func tearDown() {
-        app = nil
-    }
-    
-    func test_RecipeCreatorView_Tooltips_shouldBePresent() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        
-        // Then
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
-        
-        let ingredientsToolTipTextViewExists = ingredientsToolTipTextView.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(ingredientsToolTipTextViewExists, "Tool tip for ingredients should exist")
-        
-        let instructionsToolTipTextViewExists = instructionToolTipTextView.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(instructionsToolTipTextViewExists, "Tool tip for instructions should exist")
-    }
-    
-    func test_RecipeCreatorView_Tooltips_shouldDissapearAfterTap() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        
-        // When
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
-        ingredientsToolTipTextView.tap()
-        instructionToolTipTextView.tap()
-        
-        // Then
-        let expectationForIngredientsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: ingredientsToolTipTextView, handler: .none)
-        let expectationForInstructionsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: instructionToolTipTextView, handler: .none)
-        let testResult = XCTWaiter.wait(for: [expectationForIngredientsToolTipExistance, expectationForInstructionsToolTipExistance], timeout: standardTimeout)
-        XCTAssertEqual(testResult, .completed, "Both tooltips should not exist after tapping")
-    }
-    
-    func test_RecipeCreatorView_KeyboardToolBarNextButton_shouldExistOnTap() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
-        
-        // Then
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let nextButtonExists = nextButton.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(nextButtonExists, "Next button should exist")
-    }
-    
-    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldNotExistOnTap() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
-        
-        // Then
-        let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        let expectationForBackButton = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: backButton)
-        let testResult = XCTWaiter.wait(for: [expectationForBackButton], timeout: standardTimeout)
-        XCTAssertEqual(testResult, .completed, "Back button should not exist")
-    }
-    
-    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldExistAfterTapOnText() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        nextButton.tap()
-        
-        // Then
-        let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        let backButtonExists = backButton.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(backButtonExists, "Next button should exist")
-    }
-    
-    func test_RecipeCreatorView_keyboardToolbarNextButton_shouldSwitchFocus() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        
-        titleTextField.tap()
-        nextButton.tap()
-        
-        // Then
-        let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: ingredientsTextField)
-        let result = XCTWaiter.wait(for: [focusExpectation], timeout: standardTimeout)
-        XCTAssertEqual(result, .completed, "Ingredients text field should have focus")
-    }
-    
-    func test_RecipeCreatorView_keyboardToolBarBackButton_shouldSwitchFocus() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        
-        titleTextField.tap()
-        nextButton.tap()
-        backButton.tap()
-        
-        // Then
-        let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: titleTextField)
-        let result = XCTWaiter.wait(for: [focusExpectation], timeout: standardTimeout)
-        XCTAssertEqual(result, .completed, "Title text field should have focus")
-    }
-    
-    // This test coul go somewhere else possibly or be tested with parser view? 
-    func test_RecipeCreatorView_TextFields_shouldHoldData() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
-        
-        // When
-        enterData()
-        
-        // Then
-        XCTAssertEqual(titleTextField.value as? String, recipeTitleInput(), "The recipe title should be the same as input given")
-        XCTAssertEqual(ingredientsTextField.value as? String, ingredientsInput(), "The recipe ingredients should be the same as input given")
-        XCTAssertEqual(instructionsTextField.value as? String, instructionsInput(), "The recipe instructions should be the same as input given")
-    }
-    
-}
-
-// MARK: HELPER FUNCTIONS & STATIC INPUT PROPERTIES
-extension RecipeCreatorUITests {
-    
-    func recipeTitleInput() -> String { return "Breakfast burrito" }
-    func ingredientsInput() -> String { return "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper" }
-    func instructionsInput() -> String { return "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"}
-    
-    func navigateToRecipeCreatorView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
-    }
-    
-    func tapToolTips() {
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
-        ingredientsToolTipTextView.tap()
-        instructionToolTipTextView.tap()
-    }
-    
-    func enterData() {
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
-        
-        titleTextField.tap()
-        titleTextField.typeText(recipeTitleInput())
-        
-        nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
-        
-        nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
-        
-        finishButton.tap()
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
@@ -1,0 +1,221 @@
+//
+//  RecipeCreatorUITests.swift
+//  GymMealPrepUITests
+//
+//  Created by Tomasz Kubiak on 7/27/23.
+//
+
+import XCTest
+
+final class RecipeCreatorViewUITests: XCTestCase {
+
+    //MARK: INFORMATION ABOUT NAMING
+    /*
+     Naming structure: test_UnitOfWork_StateUnderTest_ExpectedBehaviour
+     Naming structure: test_[Struct or class]_[UI component]_[expected result]
+     Testing structure: Given, When, Then
+     */
+
+    var app: XCUIApplication!
+    
+    
+    let standardTimeout = 2.5
+    
+    override func setUp() {
+        app = XCUIApplication()
+        continueAfterFailure = false
+        app.launchArguments = ["-UITests"]
+        app.launch()
+    }
+
+    override func tearDown() {
+        app = nil
+    }
+    
+    func test_RecipeCreatorView_Tooltips_shouldBePresent() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        
+        // Then
+        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
+        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
+        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        
+        let ingredientsToolTipTextViewExists = ingredientsToolTipTextView.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(ingredientsToolTipTextViewExists, "Tool tip for ingredients should exist")
+        
+        let instructionsToolTipTextViewExists = instructionToolTipTextView.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(instructionsToolTipTextViewExists, "Tool tip for instructions should exist")
+    }
+    
+    func test_RecipeCreatorView_Tooltips_shouldDissapearAfterTap() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        
+        // When
+        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
+        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
+        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        ingredientsToolTipTextView.tap()
+        instructionToolTipTextView.tap()
+        
+        // Then
+        let expectationForIngredientsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: ingredientsToolTipTextView, handler: .none)
+        let expectationForInstructionsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: instructionToolTipTextView, handler: .none)
+        let testResult = XCTWaiter.wait(for: [expectationForIngredientsToolTipExistance, expectationForInstructionsToolTipExistance], timeout: standardTimeout)
+        XCTAssertEqual(testResult, .completed, "Both tooltips should not exist after tapping")
+    }
+    
+    func test_RecipeCreatorView_KeyboardToolBarNextButton_shouldExistOnTap() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        
+        // When
+        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
+        titleTextField.tap()
+        
+        // Then
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        let nextButtonExists = nextButton.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(nextButtonExists, "Next button should exist")
+    }
+    
+    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldNotExistOnTap() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        
+        // When
+        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
+        titleTextField.tap()
+        
+        // Then
+        let backButton = app.toolbars["Toolbar"].buttons["Back"]
+        let expectationForBackButton = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: backButton)
+        let testResult = XCTWaiter.wait(for: [expectationForBackButton], timeout: standardTimeout)
+        XCTAssertEqual(testResult, .completed, "Back button should not exist")
+    }
+    
+    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldExistAfterTapOnText() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        
+        // When
+        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
+        titleTextField.tap()
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        nextButton.tap()
+        
+        // Then
+        let backButton = app.toolbars["Toolbar"].buttons["Back"]
+        let backButtonExists = backButton.waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(backButtonExists, "Next button should exist")
+    }
+    
+    func test_RecipeCreatorView_keyboardToolbarNextButton_shouldSwitchFocus() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        
+        // When
+        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
+        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
+        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        
+        titleTextField.tap()
+        nextButton.tap()
+        
+        // Then
+        let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: ingredientsTextField)
+        let result = XCTWaiter.wait(for: [focusExpectation], timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Ingredients text field should have focus")
+    }
+    
+    func test_RecipeCreatorView_keyboardToolBarBackButton_shouldSwitchFocus() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        
+        // When
+        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
+        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        let backButton = app.toolbars["Toolbar"].buttons["Back"]
+        
+        titleTextField.tap()
+        nextButton.tap()
+        backButton.tap()
+        
+        // Then
+        let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: titleTextField)
+        let result = XCTWaiter.wait(for: [focusExpectation], timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Title text field should have focus")
+    }
+    
+    // This test coul go somewhere else possibly or be tested with parser view? 
+    func test_RecipeCreatorView_TextFields_shouldHoldData() throws {
+        // Given
+        navigateToRecipeCreatorView()
+        tapToolTips()
+        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
+        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
+        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
+        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
+        
+        // When
+        enterData()
+        
+        // Then
+        XCTAssertEqual(titleTextField.value as? String, recipeTitleInput(), "The recipe title should be the same as input given")
+        XCTAssertEqual(ingredientsTextField.value as? String, ingredientsInput(), "The recipe ingredients should be the same as input given")
+        XCTAssertEqual(instructionsTextField.value as? String, instructionsInput(), "The recipe instructions should be the same as input given")
+    }
+    
+}
+
+// MARK: HELPER FUNCTIONS & STATIC INPUT PROPERTIES
+extension RecipeCreatorViewUITests {
+    
+    func recipeTitleInput() -> String { return "Breakfast burrito" }
+    func ingredientsInput() -> String { return "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper" }
+    func instructionsInput() -> String { return "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"}
+    
+    func navigateToRecipeCreatorView() {
+        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
+        let recipiesNavigationBar = app.navigationBars["Recipes"]
+        recipiesNavigationBar.images["Back"].tap()
+        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
+        recipiesNavigationBar.buttons["Add from text"].tap()
+    }
+    
+    func tapToolTips() {
+        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
+        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
+        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        ingredientsToolTipTextView.tap()
+        instructionToolTipTextView.tap()
+    }
+    
+    func enterData() {
+        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
+        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
+        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
+        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
+        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
+        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
+        
+        titleTextField.tap()
+        titleTextField.typeText(recipeTitleInput())
+        
+        nextButton.tap()
+        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
+        
+        nextButton.tap()
+        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
+        
+        finishButton.tap()
+    }
+}


### PR DESCRIPTION
Currently there is no tests for user workflow og adding a new recipe via text input. This means that the whole workflow is not tested and prone to issues when software is developed. It is necessary to run whole UI test suite to make sure the all of the features work. With the user workflow testing, only one test can be run to quickly confirm that the user flow is working. 

This PR:
- Renames RecipeCreatorUITests to RecipeCreatorViewUITests 
- adds a RecipeCreatorUITests class that holds a test for adding a "Breakfast burrito" recipe via "Add from text", and compares the result on RecipeDetailView
