### PR TITLE
Refactor recipe creator UI tests with helper

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D637AD462A0949E2002283C5 /* DataManager+RecipeMO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D637AD452A0949E2002283C5 /* DataManager+RecipeMO.swift */; };
 		D637AD482A0961B2002283C5 /* DataManager+RecipeMOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D637AD472A0961B2002283C5 /* DataManager+RecipeMOTests.swift */; };
 		D638926E2A1BE109008CC0D6 /* IngredientHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D638926D2A1BE109008CC0D6 /* IngredientHostView.swift */; };
+		D638D0A92A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D638D0A82A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift */; };
 		D63AFA222A01238300574FE0 /* RecipeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63AFA212A01238300574FE0 /* RecipeEditorView.swift */; };
 		D63AFA242A019E2E00574FE0 /* ChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63AFA232A019E2E00574FE0 /* ChipView.swift */; };
 		D648FC4E2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D648FC4C2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift */; };
@@ -168,6 +169,7 @@
 		D637AD452A0949E2002283C5 /* DataManager+RecipeMO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+RecipeMO.swift"; sourceTree = "<group>"; };
 		D637AD472A0961B2002283C5 /* DataManager+RecipeMOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+RecipeMOTests.swift"; sourceTree = "<group>"; };
 		D638926D2A1BE109008CC0D6 /* IngredientHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientHostView.swift; sourceTree = "<group>"; };
+		D638D0A82A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorUITestsHelper.swift; sourceTree = "<group>"; };
 		D63AFA212A01238300574FE0 /* RecipeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeEditorView.swift; sourceTree = "<group>"; };
 		D63AFA232A019E2E00574FE0 /* ChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipView.swift; sourceTree = "<group>"; };
 		D648FC4C2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MealPlanMO+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				D6A92C1A2A72C85C00DB4DEF /* RecipeCreatorInstructionsViewUITests.swift */,
 				D6A92C1C2A72C87800DB4DEF /* RecipeCreatorConfirmationViewUITests.swift */,
 				D600A38B2A7AD2F500495CE3 /* RecipeCreatorUITests.swift */,
+				D638D0A82A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift */,
 			);
 			path = RecipeCreatorUITests;
 			sourceTree = "<group>";
@@ -895,6 +898,7 @@
 				D634FFA529FD42F60034B950 /* GymMealPrepUITestsLaunchTests.swift in Sources */,
 				D6E77DDE2A686B500093DB8A /* MealPlanHostViewUITests.swift in Sources */,
 				D6A92C142A72A40D00DB4DEF /* IngredientHostViewUITests.swift in Sources */,
+				D638D0A92A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift in Sources */,
 				D600A38C2A7AD2F500495CE3 /* RecipeCreatorUITests.swift in Sources */,
 				D6AD53862A699DF20091306B /* MealPlanEditorViewUITests.swift in Sources */,
 				D634FFA329FD42F60034B950 /* GymMealPrepUITests.swift in Sources */,

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
@@ -53,7 +53,7 @@ struct RecipeCreatorView: View {
                 }
                 
                 TextEditor(text: $viewModel.ingredientsEntry)
-                    .accessibilityIdentifier("IngredientsTextField")
+                    .accessibilityIdentifier("ingredients-text-field")
                     .focused($textFieldInFocus, equals: .ingredients)
                     .scrollContentBackground(.hidden)
                     .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
@@ -113,7 +113,7 @@ struct RecipeCreatorView: View {
                 } // END OF HSTACK
                 
                 TextEditor(text: $viewModel.instructionsEntry)
-                    .accessibilityIdentifier("InstructionsTextField")
+                    .accessibilityIdentifier("instructions-text-field")
                     .focused($textFieldInFocus, equals: .instructions)
                     .scrollContentBackground(.hidden)
                     .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
@@ -24,7 +24,7 @@ struct RecipeCreatorView: View {
             VStack(alignment: .leading) {
                 
                 TextField("Recipe title", text: $viewModel.recipeTitle)
-                    .accessibilityIdentifier("RecipeTitleTextField")
+                    .accessibilityIdentifier("recipe-title-text-field")
                     .focused($textFieldInFocus, equals: .title)
                     .font(.title3)
                     .fontWeight(.semibold)
@@ -49,7 +49,7 @@ struct RecipeCreatorView: View {
                     Spacer()
                     Stepper("\(viewModel.servings) \(stepperLabel)", value: $viewModel.servings)
                         .fixedSize()
-                        .accessibilityIdentifier("ServingsQuantityStepper")
+                        .accessibilityIdentifier("servings-quantity-stepper")
                 }
                 
                 TextEditor(text: $viewModel.ingredientsEntry)
@@ -75,7 +75,7 @@ struct RecipeCreatorView: View {
                                 
                                 Text("2 slices of bacon\n1 egg")
                             } // END OF VSTACK
-                            .accessibilityIdentifier("IngredientsToolTip")
+                            .accessibilityIdentifier("ingredients-tool-tip")
                             .padding()
                             .background(
                                 RoundedRectangle(cornerRadius: 20)
@@ -135,7 +135,7 @@ struct RecipeCreatorView: View {
                                 
                                 Text("1. First sample instruction.\n2. Second dample instruction")
                             } // END OF VSTACK
-                            .accessibilityIdentifier("InstructionsToolTip")
+                            .accessibilityIdentifier("instructions-tool-tip")
                             .padding()
                             .background(
                                 RoundedRectangle(cornerRadius: 20)

--- a/GymMealPrepUITests/Extensions/XCT+Focus.swift
+++ b/GymMealPrepUITests/Extensions/XCT+Focus.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 
 extension XCTestCase {
-    func waitUtilElementHasKeyboardFocus(element: XCUIElement, timeout: TimeInterval, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
+    func waitUntilElementHasKeyboardFocus(element: XCUIElement, timeout: TimeInterval, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
         let expectation = expectation(description: "waiting for element \(element) to have focus")
         
         let timer = Timer(timeInterval: 1, repeats: true) { timer in

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
@@ -203,11 +203,11 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
         let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
         // When
         cookingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
+        waitUntilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
         preparingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("25")
+        waitUntilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("25")
         waitingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("35")
+        waitUntilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("35")
         // Then
         let expectations = [
         expectation(for: NSPredicate(format: "value == '15'"), evaluatedWith: cookingTimeTextField),
@@ -236,7 +236,7 @@ extension RecipeCreatorConfirmationViewUITests {
     func addTag(withText text: String) {
         let inputTextField = app.collectionViews.cells.containing(.button, identifier: "Add").textFields["Add new tag"]
         inputTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: inputTextField, timeout: standardTimeout).typeText(text)
+        waitUntilElementHasKeyboardFocus(element: inputTextField, timeout: standardTimeout).typeText(text)
         app.collectionViews.buttons["Add"].tap()
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorConfirmationViewUITests.swift
@@ -15,10 +15,12 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
      Testing structure: Given, When, Then
      */
     var app: XCUIApplication!
+    var helper: RecipeCreatorUITestsHelper!
     let standardTimeout = 2.5
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
@@ -26,11 +28,12 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
 
     override func tearDown() {
         app = nil
+        helper = nil
     }
     
     func test_RecipeCreatorConfirmationView_UIElements_exist() {
         // Given
-        navigateToRecipeCreatorConfirmationView()
+        helper.navigateToRecipeCreatorConfirmationView()
         
         let navigationTitle = app.navigationBars.staticTexts["Add details"]
         let photoSectionHeader = app.collectionViews.staticTexts["PHOTO"]
@@ -61,10 +64,12 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     
     func test_RecipeCreatorConfirmationView_AddButton_addsTagFromTextOnTap() {
         // Given
-        navigateToRecipeCreatorConfirmationView()
+        helper.navigateToRecipeCreatorConfirmationView()
         let testInput = "Test tag"
+        
         // When
-        addTag(withText: testInput)
+        helper.addTag(tagText: testInput)
+        
         // Then
         let result = app.collectionViews.staticTexts[testInput].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Static text 'Test tag' should exist")
@@ -72,12 +77,13 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     
     func test_RecipeCreatorConfirmationView_AddButton_doesNotAddTag_whenTextFieldIsEmpty() {
         // Given
-        navigateToRecipeCreatorConfirmationView()
-        let testInput = ""
-        let addButton = app.collectionViews.buttons["Add"]
+        helper.navigateToRecipeCreatorConfirmationView()
+        
         // When
-        addTag(withText: testInput)
+        helper.addTag(tagText: "")
+        
         // Then
+        let addButton = app.collectionViews.buttons["Add"]
         let result = XCTWaiter.wait(for: [expectation(for: NSPredicate(format: "isEnabled == false"), evaluatedWith: addButton)], timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "Add button should not be enabled")
     }
@@ -85,10 +91,12 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     func test_RecipeCreatorConfirmationView_Tag_XButtonExistsAfterLongPress(){
         // Given
         let testInput = "Test tag"
-        navigateToRecipeCreatorConfirmationView()
-        addTag(withText: testInput)
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.addTag(tagText: testInput)
+        
         // When
         app.collectionViews.staticTexts[testInput].press(forDuration: 1)
+        
         // Then
         let result = app.collectionViews.buttons["x.circle"].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Delete tag button should exist")
@@ -97,12 +105,14 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     func test_RecipeCreatorConfirmationView_Tag_isRemovedAfterXButtonTap(){
         // Given
         let testInput = "Test tag"
-        navigateToRecipeCreatorConfirmationView()
-        addTag(withText: testInput)
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.addTag(tagText: testInput)
         let tag = app.collectionViews.staticTexts[testInput]
         tag.press(forDuration: 1)
+        
         // When
         app.collectionViews.buttons["x.circle"].tap()
+        
         // Then
         let result = tag.waitForNonExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "'Test tag' static test should not exist")
@@ -110,10 +120,11 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     
     func test_RecipeCreatorConfirmationView_AddPhotoButton_displaysPhotoPicker() {
         // Given
-        navigateToRecipeCreatorConfirmationView()
-        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
+        helper.navigateToRecipeCreatorConfirmationView()
+        
         // When
-        addPhotoButton.tap()
+        helper.tapAddPhotoButton()
+        
         // Then
         let result = app.navigationBars["Photos"].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "A 'Photos' navigation bar should exists after tap")
@@ -121,42 +132,40 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     
     func test_RecipeCreatorConfirmationView_RecipeImageUpdatedAfterPhotoIsPicked() {
         // Given
-        let photoId = "Photo, August 08, 2012, 11:29 PM"
-        navigateToRecipeCreatorConfirmationView()
-        app.collectionViews.buttons["add-change-photo"].tap()
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.tapAddPhotoButton()
+        
         // When
-        app.scrollViews.images[photoId].tap()
+        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
+        
         // Then
-        // photo does not have id?
         let result = app.collectionViews.descendants(matching: .image).firstMatch.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(result, "Photo '\(photoId)' should exist")
+        XCTAssertTrue(result, "Added photo should exist")
     }
     
     func test_RecipeCreatorConfirmationView_AddPhotoButton_changesLabel_whenPhotoIsLoaded() {
         // Given
-        let photoId = "Photo, August 08, 2012, 11:29 PM"
-        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
-        navigateToRecipeCreatorConfirmationView()
-        addPhotoButton.tap()
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.tapAddPhotoButton()
+        
         // When
-        app.scrollViews.images[photoId].tap()
+        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
+        
         // Then
-        XCTAssertEqual(addPhotoButton.label, "Change photo", "'add-change-photo' button should have value 'Change photo")
+        XCTAssertEqual(app.collectionViews.buttons["add-change-photo"].label, "Change photo", "'add-change-photo' button should have value 'Change photo")
     }
     
     func test_RecipeCreatorConfirmationView_DeleteButton_exists_whenPhotoIsLoaded() {
         // Given
-        let photoId = "Photo, August 08, 2012, 11:29 PM"
-        let addPhotoButton = app.collectionViews.buttons["add-change-photo"]
-        let deletePhotoButton = app.collectionViews.buttons["delete-photo"]
-        navigateToRecipeCreatorConfirmationView()
-        addPhotoButton.tap()
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.tapAddPhotoButton()
+        
         // When
-        app.scrollViews.images[photoId].tap()
+        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
+        
         // Then
-        let expectations = [expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: deletePhotoButton)]
-        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
-        XCTAssertEqual(result, .completed, "Delete photo button should exist")
+        let result = app.collectionViews.buttons["delete-photo"].waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Delete photo button should exist")
     }
     
     // TOMASZ: FOR THIS TEST TO OPERATE ASSET ID HAS TO BE OBTAINED FROM PHOTO PICKER
@@ -180,63 +189,42 @@ final class RecipeCreatorConfirmationViewUITests: XCTestCase {
     */
     func test_RecipeCreatorConfirmationView_DeleteButton_removesPhotoAndItself_whenTaped() {
         // Given
-        let deletePhotoButton = app.collectionViews.buttons["delete-photo"]
-        let photoId = "Photo, August 08, 2012, 11:29 PM"
-        navigateToRecipeCreatorConfirmationView()
-        app.collectionViews.buttons["add-change-photo"].tap()
-        app.scrollViews.images[photoId].tap()
+        helper.navigateToRecipeCreatorConfirmationView()
+        helper.tapAddPhotoButton()
+        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
+        
         // When
-        deletePhotoButton.tap()
+        helper.tapDeletePhotoButton()
+        
         // Then
         let predicate = NSPredicate(format: "exists == false")
-        let expectations = [expectation(for: predicate, evaluatedWith: deletePhotoButton),
-        expectation(for: predicate, evaluatedWith: app.collectionViews.descendants(matching: .image).firstMatch)]
+        let expectations = [
+            expectation(for: predicate, evaluatedWith: app.collectionViews.buttons["delete-photo"]),
+            expectation(for: predicate, evaluatedWith: app.collectionViews.descendants(matching: .image).firstMatch)]
+        
         let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
-        XCTAssertEqual(result, .completed, "Photo '\(photoId)' and delete button should not exist")
+        XCTAssertEqual(result, .completed, "Photo and delete button should not exist")
     }
 
     func test_RecipeCreatorConfirmationView_TimeTextFields_areEditable() {
         // Given
-        navigateToRecipeCreatorConfirmationView()
-        let cookingTimeTextField = app.collectionViews.textFields["cooking-time-text-field"]
-        let preparingTimeTextField = app.collectionViews.textFields["preparing-time-text-field"]
-        let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
+        helper.navigateToRecipeCreatorConfirmationView()
+        
         // When
-        cookingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
-        preparingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("25")
-        waitingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("35")
+        helper.enterCookingTimes(cookingTime: "15", preparingTime: "25", waitingTime: "35")
+        
         // Then
         let expectations = [
-        expectation(for: NSPredicate(format: "value == '15'"), evaluatedWith: cookingTimeTextField),
-        expectation(for: NSPredicate(format: "value == '25'"), evaluatedWith: preparingTimeTextField),
-        expectation(for: NSPredicate(format: "value == '35'"), evaluatedWith: waitingTimeTextField)]
+        expectation(for: NSPredicate(format: "value == '15'"),
+                    evaluatedWith: app.collectionViews.textFields["cooking-time-text-field"]),
+        expectation(for: NSPredicate(format: "value == '25'"),
+                    evaluatedWith: app.collectionViews.textFields["preparing-time-text-field"]),
+        expectation(for: NSPredicate(format: "value == '35'"),
+                    evaluatedWith: app.collectionViews.textFields["waiting-time-text-field"])
+        ]
         
         let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "The field values should match the typed in values")
     }
     
-}
-
-extension RecipeCreatorConfirmationViewUITests {
-    
-    func navigateToRecipeCreatorConfirmationView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
-        app.staticTexts["advance-stage-button"].tap()
-        app.staticTexts["advance-stage-button"].tap()
-        app.staticTexts["advance-stage-button"].tap()
-    }
-    
-    func addTag(withText text: String) {
-        let inputTextField = app.collectionViews.cells.containing(.button, identifier: "Add").textFields["Add new tag"]
-        inputTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: inputTextField, timeout: standardTimeout).typeText(text)
-        app.collectionViews.buttons["Add"].tap()
-    }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorHostViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorHostViewUITests.swift
@@ -17,13 +17,12 @@ final class RecipeCreatorHostViewUITests: XCTestCase {
      */
 
     var app: XCUIApplication!
-    
-    //MARK: static input properties
-    
+    var helper: RecipeCreatorUITestsHelper!
     let standardTimeout = 2.5
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(app: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
@@ -31,97 +30,91 @@ final class RecipeCreatorHostViewUITests: XCTestCase {
 
     override func tearDown() {
         app = nil
+        helper = nil
     }
     
     func test_RecipeCreatorHostView_stageControl_exists() {
         // Given
-        navigateToRecipeCreatorView()
-        let matchIngredientsButton = app.staticTexts["Match ingredients"]
+        helper.navigateToRecipeCreatorView()
         
         // Then
-        let result = matchIngredientsButton.waitForExistence(timeout: standardTimeout)
+        let result = app.staticTexts["Match ingredients"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "'Match ingredients' buton should exits")
     }
     
     func test_RecipeCreatorHostView_StageControls_navigatesToParserViewOnTap() {
         // Given
-        navigateToRecipeCreatorView()
-        let matchIngredientsButton = app.staticTexts["Match ingredients"]
-        let matchIngredientsTitle = app.navigationBars.staticTexts["Match ingredients"]
+        helper.navigateToRecipeCreatorView()
         
         // When
-        matchIngredientsButton.tap()
+        helper.advanceStage()
         
         // Then
-        let result = matchIngredientsTitle.waitForExistence(timeout: standardTimeout)
+        let result = app.navigationBars.staticTexts["Match ingredients"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Navigation titile 'Match ingredients' should exist")
     }
     
     func test_RecipeCreatorHostView_StageControls_BackButtonAppearsOnAdvancedStage() {
         // Given
-        navigateToRecipeCreatorView()
-        let matchIngredientsButton = app.staticTexts["Match ingredients"]
-        let backButton = app.images["back-button"]
+        helper.navigateToRecipeCreatorView()
         
         // When
-        matchIngredientsButton.tap()
+        helper.advanceStage()
         
         // Then
-        let result = backButton.waitForExistence(timeout: standardTimeout)
+        let result = app.images["back-button"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Back button should exist")
     }
     
     func test_RecipeCreatorHostView_StageControls_ForwardButtonShouldExistAfterBackButtonTap() {
         // Given
-        navigateToRecipeCreatorView()
-        let matchIngredientsButton = app.staticTexts["Match ingredients"]
-        let backButton = app.images["back-button"]
-        let nextButton = app.images["next-button"]
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage()
         
         // When
-        matchIngredientsButton.tap()
-        _ = backButton.waitForExistence(timeout: standardTimeout)
-        backButton.tap()
+        helper.goToLastStage()
         
         // Then
-        let result = nextButton.waitForExistence(timeout: standardTimeout)
+        let result = app.images["next-button"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "Next button should exist")
     }
 
     func test_RecipeCreatorHostView_StageControls_displayCorrectButtonLabelsForParserView() {
         // Given
-        navigateToRecipeCreatorView()
-        let advanceStageButton = app.staticTexts["advance-stage-button"]
+        helper.navigateToRecipeCreatorView()
         
         // When
-        advanceStageButton.tap()
+        helper.advanceStage()
         
         // Then
-        let result = app.staticTexts["Confirm ingredients"].waitForExistence(timeout: standardTimeout)
+        let result = app.staticTexts["Confirm ingredients"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "'Confirm ingredients' static text should exist")
     }
+    
     func test_RecipeCreatorHostView_StageControls_displayCorrectButtonLabelsForInstructionView() {
         // Given
-        navigateToRecipeCreatorView()
-        let advanceStageButton = app.staticTexts["advance-stage-button"]
+        helper.navigateToRecipeCreatorView()
         
         // When
-        advanceStageButton.tap()
-        advanceStageButton.tap()
+        helper.advanceStage(numberOfStages: 2)
         
         // Then
-        let result = app.staticTexts["Confirm instructions"].waitForExistence(timeout: standardTimeout)
+        let result = app.staticTexts["Confirm instructions"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "'Confirm instructions' static text should exist")
     }
+    
     func test_RecipeCreatorHostView_StageControls_displayCorrectButtonLabelsForConfirmationView() {
         // Given
-        navigateToRecipeCreatorView()
-        let advanceStageButton = app.staticTexts["advance-stage-button"]
+        helper.navigateToRecipeCreatorView()
         
         // When
-        advanceStageButton.tap()
-        advanceStageButton.tap()
-        advanceStageButton.tap()
+        helper.advanceStage(numberOfStages: 3)
         
         // Then
         let predicate = NSPredicate(format: "exists == true")
@@ -131,17 +124,5 @@ final class RecipeCreatorHostViewUITests: XCTestCase {
             expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: app.images["next-button"])]
         let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "Static texts 'Save and exit' and 'Save and open' should exist. Next button should not exist")
-    }
-}
-
-//MARK: HELPER FUNCTIONS
-extension RecipeCreatorHostViewUITests {
-    
-    func navigateToRecipeCreatorView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorHostViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorHostViewUITests.swift
@@ -22,7 +22,7 @@ final class RecipeCreatorHostViewUITests: XCTestCase {
     
     override func setUp() {
         app = XCUIApplication()
-        helper = RecipeCreatorUITestsHelper(app: app)
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
@@ -160,7 +160,7 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
         // When
         let textEditor = app.collectionViews.cells.containing(.staticText, identifier: "1").textViews.firstMatch
         textEditor.tap()
-        waitUtilElementHasKeyboardFocus(element: textEditor, timeout: standardTimeout).typeText(testText)
+        waitUntilElementHasKeyboardFocus(element: textEditor, timeout: standardTimeout).typeText(testText)
         addButton.tap()
         // Then
         XCTAssertEqual(textEditor.value as! String, testText, "Text in text editor should be equal to testText")
@@ -204,10 +204,10 @@ extension RecipeCreatorInstructionsViewUITests {
         titleTextField.tap()
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput)
+        waitUntilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput)
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput)
+        waitUntilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput)
         finishButton.tap()
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
@@ -15,12 +15,12 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
      Testing structure: Given, When, Then
      */
     var app: XCUIApplication!
+    var helper: RecipeCreatorUITestsHelper!
     let standardTimeout = 2.5
-    let ingredientsInput = "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper"
-    let instructionsInput = "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
@@ -28,82 +28,76 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
 
     override func tearDown() {
         app = nil
+        helper = nil
     }
     
     func test_RecipeCreatorInstructionsView_NavigationTitle_isDisplayed() {
         // Given
-        navigateToRecipeCreatorView()
+        helper.navigateToRecipeCreatorView()
         
         // When
-        advanceStage()
-        advanceStage()
+        helper.advanceStage(numberOfStages: 2)
         
         // Then
-        let title = app.navigationBars["Instructions"]
-        let result = title.waitForExistence(timeout: standardTimeout)
+        let result = app.navigationBars["Instructions"].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result,"'Instructions' navigation titile should exist")
     }
     
     func test_RecipeCreatorInstructionsView_AddInstructionsButton_exists() {
         // Given
-        navigateToRecipeCreatorView()
+        helper.navigateToRecipeCreatorView()
         
         // When
-        advanceStage()
-        advanceStage()
+        helper.advanceStage(numberOfStages: 2)
         
         // Then
-        let addButton = app.collectionViews.images["add-instruction-button"]
-        let result = addButton.waitForExistence(timeout: standardTimeout)
+        let result = app.collectionViews.images["add-instruction-button"]
+            .waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result,"'Add' button should exist")
     }
     
     func test_RecipeCreatorInstructionsView_AddInstructionsButton_AddsCellOnTap() {
         // Given
-        navigateToRecipeCreatorView()
-        advanceStage()
-        advanceStage()
-        let startingAmountOfCells = app.collectionViews.cells.count
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage(numberOfStages: 2)
         
         // When
         app.collectionViews.images["add-instruction-button"].tap()
         
         // Then
-        let resultingAmountOfCells = app.collectionViews.cells.count
-        XCTAssertEqual(resultingAmountOfCells - startingAmountOfCells, 1, "Difference in cell counts should be 1")
+        XCTAssertEqual(app.collectionViews.cells.count, 2, "There should be 2 cells existing")
     }
     
     func test_RecipeCreatorInstructionsView_newInstructionCell_hasNumberAndTextField() {
         // Given
-        navigateToRecipeCreatorView()
-        advanceStage()
-        advanceStage()
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage(numberOfStages: 2)
         
         // When
-        app.collectionViews.images["add-instruction-button"].tap()
+        helper.tapAddInstructionButton()
         
         // Then
         let predicate = NSPredicate(format: "exists == true")
         let expectations = [
             expectation(for: predicate, evaluatedWith: app.collectionViews.staticTexts["1"]),
-            expectation(for: predicate, evaluatedWith: app.collectionViews.textFields.firstMatch)]
+            expectation(for: predicate, evaluatedWith: app.collectionViews.textViews.firstMatch)]
         let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "A number 1 text and text field should exist in collection view")
     }
-    //Note - the test has to add ingredients otherwise the app will not parse instructions 
+
     func test_RecipeCreatorInstructionsView_instructionCells_areShowingWithInputFromCreator() {
         // Given
-        navigateToRecipeCreatorView()
-        enterData()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
+        helper.enterData()
         
         // When
-        advanceStage()
-        advanceStage()
+        helper.advanceStage(numberOfStages: 2)
         
         // Then
         var expectedTextFields = [String]()
         
-        for string in instructionsInput.components(separatedBy: "\n") {
+        for string in RecipeCreatorUITestsHelper.RecipeInputStrings.instructionsInput.components(separatedBy: "\n") {
             expectedTextFields.append(String(string.dropFirst(3)))
         }
         
@@ -118,11 +112,10 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
     
     func test_RecipeCreatorInstructionsView_instructionCell_showDeleteButton_WhenSwipedLeft() {
         // Given
-        navigateToRecipeCreatorView()
-        advanceStage()
-        advanceStage()
-        app.collectionViews.cells.images["add-instruction-button"].tap()
-        
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage(numberOfStages: 2)
+        helper.tapAddInstructionButton()
+
         // When
         _ = XCTWaiter.wait(for: [expectation(for: NSPredicate(format: "count == 2"), evaluatedWith: app.collectionViews.cells)])
         app.collectionViews.cells.firstMatch.swipeLeft()
@@ -134,10 +127,10 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
     
     func test_RecipeCreatorInstructionsView_instructionCell_isRemovedOnDeleteButtonTap() {
         // Given
-        navigateToRecipeCreatorView()
-        advanceStage()
-        advanceStage()
-        app.collectionViews.cells.images["add-instruction-button"].tap()
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage(numberOfStages: 2)
+        helper.tapAddInstructionButton()
+        
         _ = XCTWaiter.wait(for: [expectation(for: NSPredicate(format: "count == 2"), evaluatedWith: app.collectionViews.cells)], timeout: standardTimeout)
         
         // When
@@ -152,62 +145,33 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
     func testRecipeCreatorInstructionView_instructionCell_isEditableAndHoldingData() {
         // Given
         let testText = "Test instruction text"
-        let addButton = app.collectionViews.cells.images["add-instruction-button"]
-        navigateToRecipeCreatorView()
-        advanceStage()
-        advanceStage()
-        addButton.tap()
+        helper.navigateToRecipeCreatorView()
+        helper.advanceStage(numberOfStages: 2)
+        helper.tapAddInstructionButton()
+        
         // When
         let textEditor = app.collectionViews.cells.containing(.staticText, identifier: "1").textViews.firstMatch
         textEditor.tap()
         waitUntilElementHasKeyboardFocus(element: textEditor, timeout: standardTimeout).typeText(testText)
-        addButton.tap()
+        helper.tapAddInstructionButton()
         // Then
         XCTAssertEqual(textEditor.value as! String, testText, "Text in text editor should be equal to testText")
     }
     
     func test_RecipeCreatorInstructionsView_instructionCell_isUpdatingStepTextOnMove() {
         // Given
-        navigateToRecipeCreatorView()
-        enterData()
-        advanceStage()
-        advanceStage()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
+        helper.enterData()
+        helper.advanceStage(numberOfStages: 2)
+    
         let firstCell = app.collectionViews.cells.firstMatch
         // When
         app.collectionViews.cells.element(boundBy: 3).press(forDuration: 0.5, thenDragTo: firstCell)
         // Then
+        // this does not make sense really? we should already have one cell above as a header?
         let result = app.collectionViews.cells.element(boundBy: 0).staticTexts["1"].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "On first row static text '1' should exist")
     }
 }
 
-// MARK: HELPER FUNCTIONS
-extension RecipeCreatorInstructionsViewUITests {
-    func advanceStage() {
-        app.staticTexts["advance-stage-button"].tap()
-    }
-    func navigateToRecipeCreatorView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
-    }
-    func enterData() {
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
-        
-        titleTextField.tap()
-        
-        nextButton.tap()
-        waitUntilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput)
-        
-        nextButton.tap()
-        waitUntilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput)
-        finishButton.tap()
-    }
-}

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorParserViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorParserViewUITests.swift
@@ -16,6 +16,7 @@ final class RecipeCreatorParserViewUITests: XCTestCase {
      */
 
     var app: XCUIApplication!
+    var helper: RecipeCreatorUITestsHelper!
     let standardTimeout = 2.5
     let recipeTitleInput = "Breakfast burrito"
     let ingredientsInput = "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper"
@@ -23,6 +24,7 @@ final class RecipeCreatorParserViewUITests: XCTestCase {
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
@@ -30,6 +32,7 @@ final class RecipeCreatorParserViewUITests: XCTestCase {
 
     override func tearDown() {
         app = nil
+        helper = nil
     }
     
     func test_RecipeCreatorParserView_StaticTexts_Shows0CellsWhenNoIngredientsToParse() {

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorParserViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorParserViewUITests.swift
@@ -159,10 +159,10 @@ extension RecipeCreatorParserViewUITests {
         titleTextField.typeText(recipeTitleInput)
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput)
+        waitUntilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput)
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput)
+        waitUntilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput)
         
         finishButton.tap()
     }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
@@ -86,11 +86,11 @@ extension RecipeCreatorUITests {
         let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
         
         cookingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
+        waitUntilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
         preparingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("10")
+        waitUntilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("10")
         waitingTimeTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("0")
+        waitUntilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("0")
     }
     
     func saveAndOpen() {
@@ -107,7 +107,7 @@ extension RecipeCreatorUITests {
     func addTag(text: String) {
         let tagTextField = app.collectionViews.cells.textFields["Add new tag"]
         tagTextField.tap()
-        waitUtilElementHasKeyboardFocus(element: tagTextField, timeout: standardTimeout).typeText(text)
+        waitUntilElementHasKeyboardFocus(element: tagTextField, timeout: standardTimeout).typeText(text)
         app.collectionViews.cells.buttons["Add"].tap()
     }
     func addPhoto() {
@@ -142,10 +142,10 @@ extension RecipeCreatorUITests {
         titleTextField.typeText(recipeTitleInput())
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
+        waitUntilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
         
         nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
+        waitUntilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
         
         finishButton.tap()
     }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITests.swift
@@ -18,13 +18,14 @@ final class RecipeCreatorUITests: XCTestCase {
      */
 
     var app: XCUIApplication!
-    
+    var helper: RecipeCreatorUITestsHelper!
     //MARK: static input properties
     
     let standardTimeout = 2.5
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
@@ -32,141 +33,41 @@ final class RecipeCreatorUITests: XCTestCase {
 
     override func tearDown() {
         app = nil
+        helper = nil
     }
     
     func test_RecipeCreator_UserAddingRecipeFromText() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        enterData()
-        advanceStage()
-        advanceStage()
-        advanceStage()
-        addPhoto()
-        typeInCookingTimes()
-        addTags(tagsText: tagsInput())
+        let tags = ["breakfast", "mexican", "burrito", "freezer-friendly"]
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
+        helper.enterData()
+        helper.advanceStage(numberOfStages: 3)
+        helper.addPhoto(photoId: "Photo, August 08, 2012, 11:29 PM")
+        helper.enterCookingTimes(cookingTime: "15",
+                                 preparingTime: "10",
+                                 waitingTime: "0")
+        helper.addTags(tagTexts: tags)
+        
         // When
-        saveAndOpen()
+        helper.tapSaveAndOpenButton()
+        
         // Then
-        let expectations = checkInputDataOnRecipeDetailView()
-        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
-        XCTAssertEqual(result, .completed, "Basic elements should exist")
-    }
-}
-
-extension RecipeCreatorUITests {
-    func checkInputDataOnRecipeDetailView() -> [XCTestExpectation]{
-        let recipeImage = app.collectionViews.images.firstMatch
-        let recipeTitle = app.collectionViews.cells.staticTexts[recipeTitleInput()]
-        let tagStaticTexts: [XCUIElement] = {
-           var array = [XCUIElement]()
-            for text in tagsInput() {
-                let staticText = app.collectionViews.staticTexts[text]
-                array.append(staticText)
+        let expectations: [XCTestExpectation] = {
+            let predicate = NSPredicate(format: "exists == true")
+            var array = [
+                expectation(for: predicate, evaluatedWith: app.collectionViews.images.firstMatch),
+                expectation(for: predicate, evaluatedWith: app.collectionViews.cells.staticTexts[RecipeCreatorUITestsHelper.RecipeInputStrings.recipeTitleInput])
+            ]
+            for tag in tags {
+                array.append(
+                    expectation(for: predicate, evaluatedWith: app.collectionViews.staticTexts[tag])
+                )
             }
             return array
         }()
-        let elementsToEvaluate: [XCUIElement] = {
-            var array = [XCUIElement]()
-            array.append(recipeImage)
-            array.append(recipeTitle)
-            array.append(contentsOf: tagStaticTexts)
-            return array
-        }()
-        let predicate = NSPredicate(format: "exists == true")
-        var expectations = [XCTestExpectation]()
-        for element in elementsToEvaluate {
-            expectations.append( expectation(for: predicate, evaluatedWith: element))
-        }
-        return expectations
-    }
-    func typeInCookingTimes() {
-        let cookingTimeTextField = app.collectionViews.textFields["cooking-time-text-field"]
-        let preparingTimeTextField = app.collectionViews.textFields["preparing-time-text-field"]
-        let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
         
-        cookingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: cookingTimeTextField, timeout: standardTimeout).typeText("15")
-        preparingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: preparingTimeTextField, timeout: standardTimeout).typeText("10")
-        waitingTimeTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: waitingTimeTextField, timeout: standardTimeout).typeText("0")
-    }
-    
-    func saveAndOpen() {
-        app.staticTexts["Save and open"].tap()
-    }
-    
-    func addTags(tagsText: [String]) {
-        for text in tagsText {
-            addTag(text: text)
-        }
-        app.keyboards.buttons["Return"].tap()
-        
-    }
-    func addTag(text: String) {
-        let tagTextField = app.collectionViews.cells.textFields["Add new tag"]
-        tagTextField.tap()
-        waitUntilElementHasKeyboardFocus(element: tagTextField, timeout: standardTimeout).typeText(text)
-        app.collectionViews.cells.buttons["Add"].tap()
-    }
-    func addPhoto() {
-        app.collectionViews.buttons["add-change-photo"].tap()
-        app.scrollViews.images["Photo, August 08, 2012, 11:29 PM"].tap()
-    }
-    func navigateToRecipeCreatorView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
-    }
-    
-    func tapToolTips() {
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
-        ingredientsToolTipTextView.tap()
-        instructionToolTipTextView.tap()
-    }
-    
-    func enterData() {
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
-        
-        titleTextField.tap()
-        titleTextField.typeText(recipeTitleInput())
-        
-        nextButton.tap()
-        waitUntilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
-        
-        nextButton.tap()
-        waitUntilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
-        
-        finishButton.tap()
-    }
-    
-    func advanceStage() {
-        app.staticTexts["advance-stage-button"].tap()
-    }
-    
-    func recipeTitleInput() -> String {
-        return "Breakfast burrito"
-    }
-    
-    func ingredientsInput() -> String {
-        return "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper"
-    }
-    
-    func instructionsInput() -> String {
-        return "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"
-    }
-    
-    func tagsInput() -> [String] {
-        ["breakfast", "mexican", "burrito", "freezer-friendly"]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Basic elements should exist")
     }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -48,6 +48,11 @@ final class RecipeCreatorUITestsHelper {
         app.staticTexts["instructions-tool-tip"].firstMatch.tap()
     }
     
+    func tapAddInstructionButton() {
+        app.collectionViews.cells.images["add-instruction-button"].tap()
+    }
+    /// Enter data in input text field on recipe creator view
+    /// To work properly it needs tool tips to not exist
     func enterData(recipeTitle: String = RecipeInputStrings.recipeTitleInput,
                    recipeIngredients: String = RecipeInputStrings.ingredientsInput,
                    recipeInstructions: String = RecipeInputStrings.instructionsInput) {

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -36,4 +36,9 @@ final class RecipeCreatorUITestsHelper {
     func goToNextStage() {
         app.images["next-button"].tap()
     }
+    
+    func tapToolTips() {
+        app.staticTexts["ingredients-tool-tip"].firstMatch.tap()
+        app.staticTexts["instructions-tool-tip"].firstMatch.tap()
+    }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -21,6 +21,7 @@ final class RecipeCreatorUITestsHelper {
         self.app = forApplication
     }
     
+    // MARK: NAVIGATION HELPERS
     func navigateToRecipeCreatorView() {
         app.tabBars["Tab Bar"].buttons["Recipes"].tap()
         let recipiesNavigationBar = app.navigationBars["Recipes"]
@@ -40,6 +41,7 @@ final class RecipeCreatorUITestsHelper {
         }
     }
     
+    // MARK: TAP ELEMENT FUNCTIONS
     func goToLastStage() {
         app.images["back-button"].tap()
     }
@@ -65,6 +67,11 @@ final class RecipeCreatorUITestsHelper {
         app.collectionViews.buttons["delete-photo"].tap()
     }
     
+    func tapSaveAndOpenButton() {
+        app.staticTexts["Save and open"].tap()
+    }
+    
+    // MARK: INPUT DATA FUNCTIONS
     /// Enter data in input text field on recipe creator view
     /// To work properly it needs tool tips to not exist
     func enterData(recipeTitle: String = RecipeInputStrings.recipeTitleInput,
@@ -103,6 +110,13 @@ final class RecipeCreatorUITestsHelper {
         waitingTimeTextField.typeText("35")
     }
     
+    func addTags(tagTexts: [String]) {
+        for tagText in tagTexts {
+            addTag(tagText: tagText)
+        }
+        app.keyboards.buttons["Return"].tap()
+    }
+    
     func addTag(tagText: String){
         let inputTextField = app.collectionViews.cells.containing(.button, identifier: "Add").textFields["Add new tag"]
         inputTextField.tap()
@@ -110,5 +124,9 @@ final class RecipeCreatorUITestsHelper {
         app.collectionViews.buttons["Add"].tap()
     }
     
+    func addPhoto(photoId: String = "Photo, August 08, 2012, 11:29 PM") {
+        app.collectionViews.buttons["add-change-photo"].tap()
+        app.scrollViews.images[photoId].tap()
+    }
     
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -9,6 +9,12 @@ import XCTest
 /// This is a class that can handle the interactions with RecipeCreator views
 final class RecipeCreatorUITestsHelper {
     
+    struct RecipeInputStrings {
+        static let recipeTitleInput: String = "Breakfast burrito"
+        static let ingredientsInput: String = "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper"
+        static let instructionsInput: String = "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"
+    }
+    
     var app: XCUIApplication!
     
     init(forApplication: XCUIApplication!) {
@@ -41,4 +47,27 @@ final class RecipeCreatorUITestsHelper {
         app.staticTexts["ingredients-tool-tip"].firstMatch.tap()
         app.staticTexts["instructions-tool-tip"].firstMatch.tap()
     }
+    
+    func enterData(recipeTitle: String = RecipeInputStrings.recipeTitleInput,
+                   recipeIngredients: String = RecipeInputStrings.ingredientsInput,
+                   recipeInstructions: String = RecipeInputStrings.instructionsInput) {
+        
+        let titleTextField = app.scrollViews.textFields["recipe-title-text-field"]
+        let ingredientsTextField = app.scrollViews.textViews["ingredients-text-field"]
+        let instructionsTextField = app.scrollViews.textViews["instructions-text-field"]
+        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
+        
+        titleTextField.tap()
+        titleTextField.typeText(recipeTitle)
+        
+        ingredientsTextField.tap()
+        ingredientsTextField.typeText(recipeIngredients)
+        
+        instructionsTextField.tap()
+        instructionsTextField.typeText(recipeInstructions)
+        
+        finishButton.tap()
+    }
+    
+    
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -29,6 +29,11 @@ final class RecipeCreatorUITestsHelper {
         recipiesNavigationBar.buttons["Add from text"].tap()
     }
     
+    func navigateToRecipeCreatorConfirmationView() {
+        navigateToRecipeCreatorView()
+        advanceStage(numberOfStages: 3)
+    }
+    
     func advanceStage(numberOfStages i: Int = 1) {
         for _ in 0..<i {
             app.staticTexts["advance-stage-button"].tap()
@@ -51,6 +56,15 @@ final class RecipeCreatorUITestsHelper {
     func tapAddInstructionButton() {
         app.collectionViews.cells.images["add-instruction-button"].tap()
     }
+    
+    func tapAddPhotoButton() {
+        app.collectionViews.buttons["add-change-photo"].tap()
+    }
+    
+    func tapDeletePhotoButton() {
+        app.collectionViews.buttons["delete-photo"].tap()
+    }
+    
     /// Enter data in input text field on recipe creator view
     /// To work properly it needs tool tips to not exist
     func enterData(recipeTitle: String = RecipeInputStrings.recipeTitleInput,
@@ -72,6 +86,28 @@ final class RecipeCreatorUITestsHelper {
         instructionsTextField.typeText(recipeInstructions)
         
         finishButton.tap()
+    }
+    
+    func enterCookingTimes(cookingTime: String, preparingTime: String, waitingTime: String) {
+        let cookingTimeTextField = app.collectionViews.textFields["cooking-time-text-field"]
+        let preparingTimeTextField = app.collectionViews.textFields["preparing-time-text-field"]
+        let waitingTimeTextField = app.collectionViews.textFields["waiting-time-text-field"]
+        
+        cookingTimeTextField.tap()
+        cookingTimeTextField.typeText("15")
+        
+        preparingTimeTextField.tap()
+        preparingTimeTextField.typeText("25")
+        
+        waitingTimeTextField.tap()
+        waitingTimeTextField.typeText("35")
+    }
+    
+    func addTag(tagText: String){
+        let inputTextField = app.collectionViews.cells.containing(.button, identifier: "Add").textFields["Add new tag"]
+        inputTextField.tap()
+        inputTextField.typeText(tagText)
+        app.collectionViews.buttons["Add"].tap()
     }
     
     

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -11,8 +11,8 @@ final class RecipeCreatorUITestsHelper {
     
     var app: XCUIApplication!
     
-    init(app: XCUIApplication!) {
-        self.app = app
+    init(forApplication: XCUIApplication!) {
+        self.app = forApplication
     }
     
     func navigateToRecipeCreatorView() {

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -5,4 +5,35 @@
 //  Created by Tomasz Kubiak on 8/4/23.
 //
 
-import Foundation
+import XCTest
+/// This is a class that can handle the interactions with RecipeCreator views
+final class RecipeCreatorUITestsHelper {
+    
+    var app: XCUIApplication!
+    
+    init(app: XCUIApplication!) {
+        self.app = app
+    }
+    
+    func navigateToRecipeCreatorView() {
+        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
+        let recipiesNavigationBar = app.navigationBars["Recipes"]
+        recipiesNavigationBar.images["Back"].tap()
+        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
+        recipiesNavigationBar.buttons["Add from text"].tap()
+    }
+    
+    func advanceStage(numberOfStages i: Int = 1) {
+        for _ in 0..<i {
+            app.staticTexts["advance-stage-button"].tap()
+        }
+    }
+    
+    func goToLastStage() {
+        app.images["back-button"].tap()
+    }
+    
+    func goToNextStage() {
+        app.images["next-button"].tap()
+    }
+}

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorUITestsHelper.swift
@@ -1,0 +1,8 @@
+//
+//  RecipeCreatorUITestsHelper.swift
+//  GymMealPrepUITests
+//
+//  Created by Tomasz Kubiak on 8/4/23.
+//
+
+import Foundation

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
@@ -17,18 +17,19 @@ final class RecipeCreatorViewUITests: XCTestCase {
      */
 
     var app: XCUIApplication!
-    
-    
+    var helper: RecipeCreatorUITestsHelper!
     let standardTimeout = 2.5
     
     override func setUp() {
         app = XCUIApplication()
+        helper = RecipeCreatorUITestsHelper(forApplication: app)
         continueAfterFailure = false
         app.launchArguments = ["-UITests"]
         app.launch()
     }
 
     override func tearDown() {
+        helper = nil
         app = nil
     }
     

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
@@ -52,7 +52,7 @@ final class RecipeCreatorViewUITests: XCTestCase {
     
     func test_RecipeCreatorView_Tooltips_shouldDissapearAfterTap() {
         // Given
-        navigateToRecipeCreatorView()
+        helper.navigateToRecipeCreatorView()
         
         // When
         helper.tapToolTips()
@@ -89,57 +89,47 @@ final class RecipeCreatorViewUITests: XCTestCase {
         XCTAssertEqual(result, .completed, "Next button should exist, back button should not exist")
     }
     
-    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldExistAfterTapOnText() throws {
+    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldExistAfterTapOnNext() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
         
         // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        nextButton.tap()
+        app.textFields["recipe-title-text-field"].tap()
+        app.toolbars["Toolbar"].buttons["Next"].tap()
         
         // Then
-        let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        let backButtonExists = backButton.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(backButtonExists, "Next button should exist")
+        let result = app.toolbars["Toolbar"].buttons["Back"]
+            .waitForExistence(timeout: standardTimeout)
+        XCTAssertTrue(result, "Back button should exist")
     }
     
-    func test_RecipeCreatorView_keyboardToolbarNextButton_shouldSwitchFocus() throws {
+    func test_RecipeCreatorView_keyboardToolbarNextButton_shouldSwitchFocus() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
         
         // When
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        
-        titleTextField.tap()
-        nextButton.tap()
+        app.textFields["recipe-title-text-field"].tap()
+        app.toolbars["Toolbar"].buttons["Next"].tap()
         
         // Then
+        let ingredientsTextField = app.scrollViews.textViews["ingredients-text-field"]
         let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: ingredientsTextField)
         let result = XCTWaiter.wait(for: [focusExpectation], timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "Ingredients text field should have focus")
     }
     
-    func test_RecipeCreatorView_keyboardToolBarBackButton_shouldSwitchFocus() throws {
+    func test_RecipeCreatorView_keyboardToolBarBackButton_shouldSwitchFocus() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
+        let titleTextField = app.scrollViews.textFields["recipe-title-text-field"]
         
         // When
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        
         titleTextField.tap()
-        nextButton.tap()
-        backButton.tap()
+        app.toolbars["Toolbar"].buttons["Next"].tap()
+        app.toolbars["Toolbar"].buttons["Back"].tap()
         
         // Then
         let focusExpectation = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: titleTextField)
@@ -147,67 +137,23 @@ final class RecipeCreatorViewUITests: XCTestCase {
         XCTAssertEqual(result, .completed, "Title text field should have focus")
     }
     
-    // This test coul go somewhere else possibly or be tested with parser view? 
-    func test_RecipeCreatorView_TextFields_shouldHoldData() throws {
+    func test_RecipeCreatorView_TextFields_shouldHoldData() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
         
         // When
-        enterData()
+        helper.enterData()
         
         // Then
-        XCTAssertEqual(titleTextField.value as? String, recipeTitleInput(), "The recipe title should be the same as input given")
-        XCTAssertEqual(ingredientsTextField.value as? String, ingredientsInput(), "The recipe ingredients should be the same as input given")
-        XCTAssertEqual(instructionsTextField.value as? String, instructionsInput(), "The recipe instructions should be the same as input given")
+        let titleTextField = app.scrollViews.textFields["recipe-title-text-field"]
+        let ingredientsTextField = app.scrollViews.textViews["ingredients-text-field"]
+        let instructionsTextField = app.scrollViews.textViews["instructions-text-field"]
+        
+        
+        XCTAssertEqual(titleTextField.value as? String, RecipeCreatorUITestsHelper.RecipeInputStrings.recipeTitleInput, "The recipe title should be the same as input given")
+        XCTAssertEqual(ingredientsTextField.value as? String, RecipeCreatorUITestsHelper.RecipeInputStrings.ingredientsInput, "The recipe ingredients should be the same as input given")
+        XCTAssertEqual(instructionsTextField.value as? String, RecipeCreatorUITestsHelper.RecipeInputStrings.instructionsInput, "The recipe instructions should be the same as input given")
     }
     
-}
-
-// MARK: HELPER FUNCTIONS & STATIC INPUT PROPERTIES
-extension RecipeCreatorViewUITests {
-    
-    func recipeTitleInput() -> String { return "Breakfast burrito" }
-    func ingredientsInput() -> String { return "2 eggs\n2 bacon strips\n1 flour tortilla\n28 grams of cheddar cheese\n50 grams of green bell pepper" }
-    func instructionsInput() -> String { return "1. Fry bacon strips and scramble the eggs \n2. Remove bacon and eggs, put shredded cheese on the pan. \n3. After the cheese melts, cover cheese with tortilla \n4. Flip the tortilla and put it on plate, top with the rest of ingredients. Roll the burrito.\n5. Put the burrito on the hot pan, seam side down. After 30 seconds remove and prepare for serving"}
-    
-    func navigateToRecipeCreatorView() {
-        app.tabBars["Tab Bar"].buttons["Recipes"].tap()
-        let recipiesNavigationBar = app.navigationBars["Recipes"]
-        recipiesNavigationBar.images["Back"].tap()
-        _ = recipiesNavigationBar.buttons["Add from text"].waitForExistence(timeout: 1)
-        recipiesNavigationBar.buttons["Add from text"].tap()
-    }
-    
-    func tapToolTips() {
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"recipe-title-text-field").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "ingredients-tool-tip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "instructions-tool-tip").element(boundBy: 0)
-        ingredientsToolTipTextView.tap()
-        instructionToolTipTextView.tap()
-    }
-    
-    func enterData() {
-        let recipeTitleElementsQuery = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title")
-        let titleTextField = recipeTitleElementsQuery.textFields["Recipe title"]
-        let ingredientsTextField = recipeTitleElementsQuery.textViews["IngredientsTextField"]
-        let instructionsTextField = recipeTitleElementsQuery.textViews["InstructionsTextField"]
-        let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let finishButton = app.toolbars["Toolbar"].buttons["Finish"]
-        
-        titleTextField.tap()
-        titleTextField.typeText(recipeTitleInput())
-        
-        nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: ingredientsTextField, timeout: standardTimeout).typeText(ingredientsInput())
-        
-        nextButton.tap()
-        waitUtilElementHasKeyboardFocus(element: instructionsTextField, timeout: standardTimeout).typeText(instructionsInput())
-        
-        finishButton.tap()
-    }
 }

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorViewUITests.swift
@@ -33,69 +33,60 @@ final class RecipeCreatorViewUITests: XCTestCase {
         app = nil
     }
     
-    func test_RecipeCreatorView_Tooltips_shouldBePresent() throws {
+    func test_RecipeCreatorView_Tooltips_shouldBePresent() {
         // Given
-        navigateToRecipeCreatorView()
+        helper.navigateToRecipeCreatorView()
         
         // Then
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        let ingredientsToolTip = app.staticTexts["ingredients-tool-tip"]
+        let instructionToolTip = app.staticTexts["instructions-tool-tip"]
         
-        let ingredientsToolTipTextViewExists = ingredientsToolTipTextView.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(ingredientsToolTipTextViewExists, "Tool tip for ingredients should exist")
-        
-        let instructionsToolTipTextViewExists = instructionToolTipTextView.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(instructionsToolTipTextViewExists, "Tool tip for instructions should exist")
+        let predicate = NSPredicate(format: "exists == true")
+        let expectations = [
+            expectation(for: predicate, evaluatedWith: ingredientsToolTip),
+            expectation(for: predicate, evaluatedWith: instructionToolTip)
+        ]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Tooltips for ingredients and isntructions should exist")
     }
     
-    func test_RecipeCreatorView_Tooltips_shouldDissapearAfterTap() throws {
+    func test_RecipeCreatorView_Tooltips_shouldDissapearAfterTap() {
         // Given
         navigateToRecipeCreatorView()
         
         // When
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
-        ingredientsToolTipTextView.tap()
-        instructionToolTipTextView.tap()
-        
+        helper.tapToolTips()
+
         // Then
-        let expectationForIngredientsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: ingredientsToolTipTextView, handler: .none)
-        let expectationForInstructionsToolTipExistance = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: instructionToolTipTextView, handler: .none)
-        let testResult = XCTWaiter.wait(for: [expectationForIngredientsToolTipExistance, expectationForInstructionsToolTipExistance], timeout: standardTimeout)
-        XCTAssertEqual(testResult, .completed, "Both tooltips should not exist after tapping")
+        let ingredientsToolTip = app.staticTexts["ingredients-tool-tip"]
+        let instructionToolTip = app.staticTexts["instructions-tool-tip"]
+        
+        let predicate = NSPredicate(format: "exists == false")
+        let expectations = [
+            expectation(for: predicate, evaluatedWith: ingredientsToolTip),
+            expectation(for: predicate, evaluatedWith: instructionToolTip)
+        ]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Tooltips for ingredients and isntructions should not exist after tap")
+        
     }
     
-    func test_RecipeCreatorView_KeyboardToolBarNextButton_shouldExistOnTap() throws {
+    func test_RecipeCreatorView_KeyboardToolBarButtons_shouldDisplayCorrectly_whenRecipeTitleTap() {
         // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
+        helper.navigateToRecipeCreatorView()
+        helper.tapToolTips()
         
         // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
+        app.textFields["recipe-title-text-field"].tap()
         
         // Then
         let nextButton = app.toolbars["Toolbar"].buttons["Next"]
-        let nextButtonExists = nextButton.waitForExistence(timeout: standardTimeout)
-        XCTAssertTrue(nextButtonExists, "Next button should exist")
-    }
-    
-    func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldNotExistOnTap() throws {
-        // Given
-        navigateToRecipeCreatorView()
-        tapToolTips()
-        
-        // When
-        let titleTextField  = app.scrollViews.otherElements.containing(.textField, identifier:"Recipe title").textFields["Recipe title"]
-        titleTextField.tap()
-        
-        // Then
         let backButton = app.toolbars["Toolbar"].buttons["Back"]
-        let expectationForBackButton = expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: backButton)
-        let testResult = XCTWaiter.wait(for: [expectationForBackButton], timeout: standardTimeout)
-        XCTAssertEqual(testResult, .completed, "Back button should not exist")
+        let expectations = [
+            expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: nextButton),
+            expectation(for: NSPredicate(format: "exists == false"), evaluatedWith: backButton)]
+        let result = XCTWaiter.wait(for: expectations, timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "Next button should exist, back button should not exist")
     }
     
     func test_RecipeCreatorView_KeyboardToolBarBackButton_shouldExistAfterTapOnText() throws {
@@ -193,9 +184,9 @@ extension RecipeCreatorViewUITests {
     }
     
     func tapToolTips() {
-        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"RecipeTitleTextField").children(matching: .staticText)
-        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "IngredientsToolTip").element(boundBy: 0)
-        let instructionToolTipTextView = staticTextQuery.matching(identifier: "InstructionsToolTip").element(boundBy: 0)
+        let staticTextQuery = app.scrollViews.otherElements.containing(.textField, identifier:"recipe-title-text-field").children(matching: .staticText)
+        let ingredientsToolTipTextView = staticTextQuery.matching(identifier: "ingredients-tool-tip").element(boundBy: 0)
+        let instructionToolTipTextView = staticTextQuery.matching(identifier: "instructions-tool-tip").element(boundBy: 0)
         ingredientsToolTipTextView.tap()
         instructionToolTipTextView.tap()
     }


### PR DESCRIPTION
The current UI testing for RecipeCreator views was repeating a lot of helper functions to help with navigation and some other common tasks (like entering test recipe data into fields). When changes are presented large amount of repetitive adjustments in helper functions are needed and can lead to an error. 

This PR aims to extract all of those functions to a separate helper class, that is used by all of the testing cases. 

I added RecipeCreatorUITestsHelper class and implemented functions used in the test cases. 
I changed the tests to implement helper, rather than using helper functions present in the extensions of the test classes.