### PR TITLE
Refactor recipe creator to use enum for state control

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D638D0A92A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D638D0A82A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift */; };
 		D63AFA222A01238300574FE0 /* RecipeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63AFA212A01238300574FE0 /* RecipeEditorView.swift */; };
 		D63AFA242A019E2E00574FE0 /* ChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63AFA232A019E2E00574FE0 /* ChipView.swift */; };
+		D646D3742A8032E60086D7EF /* CaseIterable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D646D3732A8032E60086D7EF /* CaseIterable+Extensions.swift */; };
 		D648FC4E2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D648FC4C2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift */; };
 		D648FC4F2A422D0E00393AC3 /* MealPlanMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D648FC4D2A422D0E00393AC3 /* MealPlanMO+CoreDataProperties.swift */; };
 		D648FC512A422F6300393AC3 /* MealPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D648FC502A422F6300393AC3 /* MealPlan.swift */; };
@@ -172,6 +173,7 @@
 		D638D0A82A7D4E0E00C3CC87 /* RecipeCreatorUITestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeCreatorUITestsHelper.swift; sourceTree = "<group>"; };
 		D63AFA212A01238300574FE0 /* RecipeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeEditorView.swift; sourceTree = "<group>"; };
 		D63AFA232A019E2E00574FE0 /* ChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipView.swift; sourceTree = "<group>"; };
+		D646D3732A8032E60086D7EF /* CaseIterable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+Extensions.swift"; sourceTree = "<group>"; };
 		D648FC4C2A422D0E00393AC3 /* MealPlanMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MealPlanMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D648FC4D2A422D0E00393AC3 /* MealPlanMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MealPlanMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D648FC502A422F6300393AC3 /* MealPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlan.swift; sourceTree = "<group>"; };
@@ -629,6 +631,7 @@
 			isa = PBXGroup;
 			children = (
 				D6EC92F62A027EA800863F2D /* ViewExtensions.swift */,
+				D646D3732A8032E60086D7EF /* CaseIterable+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -811,6 +814,7 @@
 				D694E4072A05824A0077E72F /* IngredientMO+CoreDataClass.swift in Sources */,
 				D65E4C9D2A40EB23008C7A2F /* MealMO+CoreDataClass.swift in Sources */,
 				D6C3405429FE7458003F6E06 /* RecipeListViewModel.swift in Sources */,
+				D646D3742A8032E60086D7EF /* CaseIterable+Extensions.swift in Sources */,
 				D655E8C22A4CF813004D5079 /* MealPlanTabViewModel.swift in Sources */,
 				D69BAB252A31BBCE00E2D05D /* NutritionStripeView.swift in Sources */,
 				D69C21E92A476396002DE11A /* DataManager+MealMO.swift in Sources */,

--- a/GymMealPrep/Extensions/CaseIterable+Extensions.swift
+++ b/GymMealPrep/Extensions/CaseIterable+Extensions.swift
@@ -1,0 +1,8 @@
+//
+//  CaseIterable+Extensions.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 8/6/23.
+//
+
+import Foundation

--- a/GymMealPrep/Extensions/CaseIterable+Extensions.swift
+++ b/GymMealPrep/Extensions/CaseIterable+Extensions.swift
@@ -6,3 +6,22 @@
 //
 
 import Foundation
+
+extension CaseIterable where Self: Equatable {
+    
+    ///Returns the next enum case or the first one in case it was called on last one
+    func next() -> Self {
+        let all = Self.allCases
+        let index = all.firstIndex(of: self)!
+        let next = all.index(after: index)
+        return all[next == all.endIndex ? all.startIndex : next]
+    }
+    
+    ///Returns the previous enum case or the last one in case it was called on the first one
+    func previous() -> Self {
+        let all = Self.allCases.reversed()
+        let index = all.firstIndex(of: self)!
+        let next = all.index(after: index)
+        return all[next == all.endIndex ? all.startIndex : next]
+    }
+}

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct RecipeCreatorHostView: View, KeyboardReadable {
     
-    enum Stage: Int {
-        case webEntry = 0
-        case dataEntry = 1
-        case ingredientParsing = 2
-        case instructionParsing = 3
-        case confirmation = 4
+    enum Stage: CaseIterable {
+        case webEntry
+        case dataEntry
+        case ingredientParsing
+        case instructionParsing
+        case confirmation
     }
     
     @StateObject private var viewModel: RecipeCreatorViewModelProtocol = RecipeCreatorViewModel()

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
@@ -8,6 +8,15 @@
 import SwiftUI
 
 struct RecipeCreatorHostView: View, KeyboardReadable {
+    
+    enum Stage: Int {
+        case webEntry = 0
+        case dataEntry = 1
+        case ingredientParsing = 2
+        case instructionParsing = 3
+        case confirmation = 4
+    }
+    
     @StateObject private var viewModel: RecipeCreatorViewModelProtocol = RecipeCreatorViewModel()
     @State private var displayedStage: Int = 0
     @State private var processStage: Int = 0


### PR DESCRIPTION
The RecipeCreatorHostView uses a bunch of Int state variables to manage the state of the ui. This approach is rather prone to mistakes and generates a huge effort when additional screen is added.  

This PR changes the management of the stage of the RecipeCreatorView from using integers to using an enum containing all of the stages. 
Additionally, an extension to CaseIterable was added, to allow to call next and previous functions on the Stage enum. 