### PR TITLE
34 instructions step number not updating after move in recipecreatorinstructionview

### DIFF
--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorConfirmationView.swift
@@ -160,9 +160,6 @@ struct RecipeCreatorConfirmationView_Previews: PreviewProvider {
         override func addIngredient(_: Ingredient, _: String?) {
             // do nothing
         }
-        override func createRecipeViewModel() -> RecipeViewModel {
-            return RecipeViewModel(recipe: Recipe())
-        }
     }
     
     static var previews: some View {

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorInstructionsView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorInstructionsView.swift
@@ -59,12 +59,6 @@ struct RecipeCreatorInstructionsView_Previews: PreviewProvider {
         override func processInput() {
             print("Processing input called")
         }
-        override func createRecipeViewModel() -> RecipeViewModel {
-            var recipe = Recipe()
-            recipe.instructions = parsedInstructions
-            return RecipeViewModel(recipe: recipe, dataManager: DataManager.preview)
-            
-        }
         override func deleteInstruction(at offset: IndexSet) {
             parsedInstructions.remove(atOffsets: offset)
         }

--- a/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
@@ -96,10 +96,10 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
     override var selectedImage: PhotosPickerItem? {
         didSet {
             // this needs to change
-                Task { @MainActor in
-                    recipeImageData = await loadPhoto(from: selectedImage)
-//                        recipeImage = try await selectedImage?.loadTransferable(type: Image.self)
-                }
+            Task { @MainActor in
+                recipeImageData = await loadPhoto(from: selectedImage)
+                //                        recipeImage = try await selectedImage?.loadTransferable(type: Image.self)
+            }
         }
     }
     func loadPhoto(from imageSelection: PhotosPickerItem?) async -> Data? {
@@ -151,7 +151,7 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
         
         // send request for matching ingredients to EdamamAPI
         for searchTerm in ingredientsNLArray {
-           edamamLogicController.getIngredientsWithParsed(for: searchTerm)
+            edamamLogicController.getIngredientsWithParsed(for: searchTerm)
                 .receive(on: DispatchQueue.main)
                 .sink { completion in
                     switch completion {
@@ -238,9 +238,15 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
     override func deleteInstruction(at offset: IndexSet) {
         parsedInstructions.remove(atOffsets: offset)
     }
+    
     override func moveInstruction(fromOffset source: IndexSet, toOffset destination: Int) {
         parsedInstructions.move(fromOffsets: source, toOffset: destination)
+        for (index, instruction) in parsedInstructions.enumerated() {
+            let targetInstruction = Instruction(id: instruction.id, step: index + 1, text: instruction.text)
+            parsedInstructions[index] = targetInstruction
+        }
     }
+    
     override func addInstruction() {
         parsedInstructions.append(Instruction(step: parsedInstructions.count + 1))
     }

--- a/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
@@ -53,10 +53,6 @@ class RecipeCreatorViewModelProtocol: ObservableObject, IngredientSaveHandler {
         assertionFailure("Missing override: Please override this method in the subclass")
         return Recipe()
     }
-    func createRecipeViewModel() -> RecipeViewModel {
-        assertionFailure("Missing override: Please override this method in the subclass")
-        return RecipeViewModel(recipe: Recipe())
-    }
     func addTag() {
         assertionFailure("Missing override: Please override this method in the subclass")
     }
@@ -218,11 +214,6 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
         
         dataManager.updateAndSave(recipe: recipe)
         return recipe
-    }
-    
-    override func createRecipeViewModel() -> RecipeViewModel {
-        return RecipeViewModel(recipe:
-        Recipe(name: recipeTitle, servings: 1, timeCookingInMinutes: 0, timePreparingInMinutes: 0, timeWaitingInMinutes: 0, ingredients: [], instructions: [], tags: []))
     }
     
     override func addTag() {

--- a/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
+++ b/GymMealPrepUITests/RecipeCreatorUITests/RecipeCreatorInstructionsViewUITests.swift
@@ -170,7 +170,7 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
         XCTAssertEqual(textEditor.value as! String, testText, "Text in text editor should be equal to testText")
     }
     // TODO: SEE ISSUE #34 - UNTIL RESOLVED TEST BELOW WILL FAIL
-    /*
+    
     func test_RecipeCreatorInstructionsView_instructionCell_isUpdatingStepTextOnMove() {
         // Given
         helper.navigateToRecipeCreatorView()
@@ -186,6 +186,6 @@ final class RecipeCreatorInstructionsViewUITests: XCTestCase {
         let result = app.collectionViews.cells.element(boundBy: 0).staticTexts["1"].waitForExistence(timeout: standardTimeout)
         XCTAssertTrue(result, "On first row static text '1' should exist")
     }
-     */
+ 
 }
 


### PR DESCRIPTION
As in issue 34, moving the recipe up on the list in the recipe creator instructions view did not modify the step of the instructions set. 

This pr implements updating step of all of the instructions when one of the instructions is moved on the screen. 