### PR TITLE
Add root service container

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D60598702A37B2D000186F7F /* RecipeListTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D605986F2A37B2D000186F7F /* RecipeListTabView.swift */; };
 		D605F0EF2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D605F0EE2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift */; };
 		D614A0422A1D4FA700C55D34 /* IngredientEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D614A0412A1D4FA700C55D34 /* IngredientEditorViewModel.swift */; };
+		D61560002AEB0BEE0043BDB6 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6155FFF2AEB0BEE0043BDB6 /* Container.swift */; };
 		D61CF3A02A002A52004B31E1 /* RecipeHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61CF39F2A002A52004B31E1 /* RecipeHostView.swift */; };
 		D61E3A662A9A729400AB2527 /* K.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E3A652A9A729400AB2527 /* K.swift */; };
 		D61E3A692A9A73B700AB2527 /* SettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61E3A682A9A73B700AB2527 /* SettingsTabView.swift */; };
@@ -191,6 +192,7 @@
 		D605986F2A37B2D000186F7F /* RecipeListTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeListTabView.swift; sourceTree = "<group>"; };
 		D605F0EE2A0E1A7F006CF9C0 /* RecipeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeViewModelTests.swift; sourceTree = "<group>"; };
 		D614A0412A1D4FA700C55D34 /* IngredientEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientEditorViewModel.swift; sourceTree = "<group>"; };
+		D6155FFF2AEB0BEE0043BDB6 /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
 		D6169D942A12C95400CD9C60 /* Edamam-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Edamam-Info.plist"; sourceTree = "<group>"; };
 		D61CF39F2A002A52004B31E1 /* RecipeHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeHostView.swift; sourceTree = "<group>"; };
 		D61E3A652A9A729400AB2527 /* K.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K.swift; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 				D61E3A672A9A73A400AB2527 /* Settings */,
 				D61E3A652A9A729400AB2527 /* K.swift */,
 				D6705A642AC4A3C100CF0BA9 /* SettingsStore.swift */,
+				D6155FFF2AEB0BEE0043BDB6 /* Container.swift */,
 				D634FF8829FD42F50034B950 /* ContentView.swift */,
 				D634FFB629FD52100034B950 /* Model.xcdatamodeld */,
 				D634FF8A29FD42F60034B950 /* Assets.xcassets */,
@@ -1083,6 +1086,7 @@
 				D6C3405A29FFCE03003F6E06 /* SampleData.swift in Sources */,
 				D694E4072A05824A0077E72F /* IngredientMO+CoreDataClass.swift in Sources */,
 				D65E4C9D2A40EB23008C7A2F /* MealMO+CoreDataClass.swift in Sources */,
+				D61560002AEB0BEE0043BDB6 /* Container.swift in Sources */,
 				D6FC3CC82ACDFA56002FBE74 /* String+Extensions.swift in Sources */,
 				D6C3405429FE7458003F6E06 /* RecipeListViewModel.swift in Sources */,
 				D6FC3CCE2ACDFAF5002FBE74 /* Initializable.swift in Sources */,

--- a/GymMealPrep/Container.swift
+++ b/GymMealPrep/Container.swift
@@ -9,4 +9,6 @@ import Foundation
 
 class Container: ObservableObject {
     var settingStore: SettingStore = .init()
+    var dataManager: DataManager = .shared
+    var networkController: NetworkController = .init()
 }

--- a/GymMealPrep/Container.swift
+++ b/GymMealPrep/Container.swift
@@ -1,0 +1,12 @@
+//
+//  Container.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 26/10/2023.
+//
+
+import Foundation
+
+class Container: ObservableObject {
+    var settingStore: SettingStore = .init()
+}

--- a/GymMealPrep/ContentView.swift
+++ b/GymMealPrep/ContentView.swift
@@ -26,12 +26,12 @@ struct ContentView: View {
                         Text("Recipes")
                     }
             
-            MealPlanTabView()
-            .tabItem {
-                Image(systemName: "rectangle.grid.1x2.fill")
-                    .font(.largeTitle)
-                Text("Meal plans")
-            }
+            MealPlanTabView(viewModel: MealPlanTabViewModel(dataManager: container.dataManager))
+                .tabItem {
+                    Image(systemName: "rectangle.grid.1x2.fill")
+                        .font(.largeTitle)
+                    Text("Meal plans")
+                }
             
             SettingsTabView(viewModel: SettingsViewModel(settingStore: container.settingStore))
                 .tabItem {

--- a/GymMealPrep/ContentView.swift
+++ b/GymMealPrep/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
                     Text("Home")
                 }
             
-            RecipeListTabView()
+            RecipeListTabView(viewModel: RecipeListViewModel(dataManager: container.dataManager))
                     .tabItem {
                         Image(systemName: "square.fill.text.grid.1x2")
                             .font(.largeTitle)

--- a/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
+++ b/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
@@ -16,6 +16,7 @@ struct MealPlanEditorSheetView: View {
         case ingredient = "Adding ingredient"
         case recipe = "Adding Recipe"
     }
+    @EnvironmentObject private var container: Container
     @State private var selected: ContentType = .ingredient
     @Binding var navigationPath: NavigationPath
     
@@ -36,9 +37,10 @@ struct MealPlanEditorSheetView: View {
                     IngredientHostView(title: "Add new ingredient",
                                        buttonTitle: "Add manually",
                                        saveHandler: saveHandler,
-                                       pickerViewModel: IngredientPickerViewModel())
+                                       pickerViewModel: IngredientPickerViewModel(networkController: container.networkController))
                 case .recipe:
-                    RecipePickerView(saveHandler: saveHandler)
+                    RecipePickerView(saveHandler: saveHandler,
+                                     viewModel: RecipePickerViewModel(dataManager: container.dataManager))
                 } // END OF SWITCH
             } // END OF VSTACK
     } // END OF BODY
@@ -61,6 +63,7 @@ struct MealPlanEditorSheetView_Previews: PreviewProvider {
                 .sheet(isPresented: .constant(true)) {
                     MealPlanEditorSheetView(saveHandler: PreviewSaveHandler(), navigationPath: .constant(NavigationPath()))
                 }
+                .environmentObject(Container())
         }
         
     }

--- a/GymMealPrep/MealPlan/SubViews/RecipePickerView.swift
+++ b/GymMealPrep/MealPlan/SubViews/RecipePickerView.swift
@@ -18,7 +18,7 @@ struct RecipePickerView: View {
     var saveHandler: RecipeSaveHandler
     @StateObject private var viewModel: RecipePickerViewModel
     
-    init(saveHandler: RecipeSaveHandler, viewModel: RecipePickerViewModel = RecipePickerViewModel()) {
+    init(saveHandler: RecipeSaveHandler, viewModel: RecipePickerViewModel) {
         self.saveHandler = saveHandler
         self._viewModel = StateObject.init(wrappedValue: viewModel)
     }
@@ -53,13 +53,22 @@ struct RecipePickerView: View {
 }
 
 struct RecipePickerView_Previews: PreviewProvider {
-    class PreviewSaveHandler: RecipeSaveHandler {
+    
+    private class PreviewSaveHandler: RecipeSaveHandler {
         func addRecipe(_ recipeToSave: Recipe) {
             print("Recipe saved: \(recipeToSave.name)")
         }
     }
+    
+    private struct ContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            RecipePickerView(saveHandler: PreviewSaveHandler(),
+                             viewModel: RecipePickerViewModel(dataManager: container.dataManager))
+        }
+    }
+    
     static var previews: some View {
-        RecipePickerView(saveHandler: PreviewSaveHandler(),
-                         viewModel: RecipePickerViewModel(dataManager: .preview))
+        ContainerView()
     }
 }

--- a/GymMealPrep/MealPlan/ViewModels/MealPlanTabViewModel.swift
+++ b/GymMealPrep/MealPlan/ViewModels/MealPlanTabViewModel.swift
@@ -24,7 +24,7 @@ class MealPlanTabViewModel: MealPlanTabViewModelProtocol {
         dataManager.mealPlanArray
     }
     
-    init(dataManager: DataManager = DataManager.shared) {
+    init(dataManager: DataManager) {
         self.dataManager = dataManager
         
         dataManager.objectWillChange.sink { [weak self] _ in

--- a/GymMealPrep/MealPlan/ViewModels/MealPlanViewModel.swift
+++ b/GymMealPrep/MealPlan/ViewModels/MealPlanViewModel.swift
@@ -32,7 +32,7 @@ class MealPlanViewModel: MealPlanViewModelProtocol {
     @Published var mealPlan: MealPlan
     private var dataManager: MealPlanDataManagerProtocol
     
-    init(mealPlan: MealPlan, dataManager: MealPlanDataManagerProtocol = DataManager.shared as MealPlanDataManagerProtocol) {
+    init(mealPlan: MealPlan, dataManager: MealPlanDataManagerProtocol) {
         self.mealPlan = mealPlan
         self.dataManager = dataManager
         if let name = mealPlan.name {

--- a/GymMealPrep/MealPlan/ViewModels/RecipePickerViewModel.swift
+++ b/GymMealPrep/MealPlan/ViewModels/RecipePickerViewModel.swift
@@ -13,7 +13,7 @@ class RecipePickerViewModel: ObservableObject {
     
     private var dataManager: DataManager
     
-    init(searchTerm: String = String(), retrievedRecipes: [Recipe] = [Recipe](), dataManager: DataManager = .shared) {
+    init(searchTerm: String = String(), retrievedRecipes: [Recipe] = [Recipe](), dataManager: DataManager) {
         self.searchTerm = searchTerm
         self.retrievedRecipes = retrievedRecipes
         self.dataManager = dataManager

--- a/GymMealPrep/MealPlan/Views/MealPlanDetailView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanDetailView.swift
@@ -69,9 +69,26 @@ struct MealPlanDetailView<T: MealPlanViewModelProtocol>: View {
 }
 
 struct MealPlanDetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            MealPlanDetailView(viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan, dataManager: DataManager.preview))
+    struct PreviewContainer: View {
+        @StateObject private var container: Container
+        @StateObject private var viewModel: MealPlanViewModel
+        @State private var navigationPath: NavigationPath
+        
+        init() {
+            let container = Container()
+            self._container = StateObject(wrappedValue: container)
+            self._viewModel = StateObject(wrappedValue: .init(mealPlan: SampleData.sampleMealPlan,
+                                                              dataManager: container.dataManager))
+            self._navigationPath = State(wrappedValue: NavigationPath())
         }
+        
+        var body: some View {
+            NavigationStack {
+                MealPlanDetailView(viewModel: viewModel)
+            }
+        }
+    }
+    static var previews: some View {
+        PreviewContainer()
     }
 }

--- a/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
@@ -141,15 +141,27 @@ extension MealPlanEditorView {
 }
 
 struct MealPlanEditorView_Previews: PreviewProvider {
-    struct Containter: View {
-        @State var navigationPath = NavigationPath()
+    struct PreviewContainter: View {
+        @StateObject private var container: Container
+        @StateObject private var viewModel: MealPlanViewModel
+        @State private var navigationPath: NavigationPath
+        
+        init() {
+            let container = Container()
+            self._container = StateObject(wrappedValue: container)
+            self._viewModel = StateObject(wrappedValue: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan,
+                                                                          dataManager: container.dataManager))
+            self._navigationPath = State(wrappedValue: NavigationPath())
+        }
         var body: some View {
             NavigationStack {
-                MealPlanEditorView(viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan, dataManager: DataManager.preview), navigationPath: $navigationPath, title: "Adding new meal plan")
+                MealPlanEditorView(viewModel: viewModel,
+                                   navigationPath: $navigationPath, 
+                                   title: "Adding new meal plan")
             }
         }
     }
     static var previews: some View {
-        Containter()
+        PreviewContainter()
     }
 }

--- a/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
@@ -43,25 +43,23 @@ struct MealPlanHostView: View {
             }
     }
     func provideEditingTitle() -> String {
-        if isAddingNewMealPlan {
-         return "Adding new meal plan"
-        }
-        return "Editing meal plan"
+        isAddingNewMealPlan ? "Adding new meal plan" : "Editing meal plan"
     }
 }
 
 struct MealPlanHostView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            MealPlanHostView(
-                viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan,
-                                             dataManager: DataManager.preview),
-                navigationPath: .init(get: {
-                    return NavigationPath()
-                }, set: { navPath in
-                    print(navPath)
-                })
-                                            )
+    private struct PreviewContainerView: View {
+        @StateObject private var container = Container()
+        @State private var navPath = NavigationPath()
+        var body: some View {
+            NavigationStack {
+                MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan,
+                                                              dataManager: container.dataManager),
+                                 navigationPath: $navPath)
+            }
         }
+    }
+    static var previews: some View {
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
@@ -37,7 +37,7 @@ struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
     @State var displayType: ViewType = .list
     @State var showTitleInline: Bool = true
     
-    public init(viewModel: T = MealPlanTabViewModel()) {
+    public init(viewModel: T) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
     

--- a/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanTabView.swift
@@ -31,11 +31,11 @@ struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
             }
         }
     }
-    
-    @StateObject var viewModel: T
-    @State var navigationPath = NavigationPath()
-    @State var displayType: ViewType = .list
-    @State var showTitleInline: Bool = true
+    @EnvironmentObject private var container: Container
+    @StateObject private var viewModel: T
+    @State private var navigationPath = NavigationPath()
+    @State private var displayType: ViewType = .list
+    @State private var showTitleInline: Bool = true
     
     public init(viewModel: T) {
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -79,11 +79,20 @@ struct MealPlanTabView<T: MealPlanTabViewModelProtocol>: View {
                 .navigationDestination(for: MealPlanTabNavigationState.self) { state in
                     switch state {
                     case .showingMealPlanDetailView(let plan):
-                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: false)
+                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan,
+                                                                      dataManager: container.dataManager),
+                                         navigationPath: $navigationPath)
                     case .showingMealPlanEditingView(let plan):
-                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: true)
+                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan,
+                                                                      dataManager: container.dataManager),
+                                         navigationPath: $navigationPath,
+                                         isEditing: true)
                     case .showingMealPlanAddingView(let plan):
-                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan), navigationPath: $navigationPath, isEditing: true, isAddingNewMealPlan: true)
+                        MealPlanHostView(viewModel: MealPlanViewModel(mealPlan: plan,
+                                                                      dataManager: container.dataManager),
+                                         navigationPath: $navigationPath,
+                                         isEditing: true,
+                                         isAddingNewMealPlan: true)
                     }
                 }
         } // END OF NAV STACK

--- a/GymMealPrep/Recipe/IngredientViews/IngredientEditorView.swift
+++ b/GymMealPrep/Recipe/IngredientViews/IngredientEditorView.swift
@@ -14,7 +14,8 @@ struct IngredientEditorView: View {
     @StateObject var viewModel: IngredientEditorViewModelProtocol
     let saveAction: (Ingredient) -> Void
     
-    init(viewModel: IngredientEditorViewModelProtocol = IngredientEditorViewModel(), saveAction: @escaping (Ingredient) -> Void) {
+    init(viewModel: IngredientEditorViewModelProtocol,
+         saveAction: @escaping (Ingredient) -> Void) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
         self.saveAction = saveAction
     }

--- a/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
+++ b/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
@@ -66,7 +66,7 @@ struct IngredientHostView_Previews: PreviewProvider {
             }
             .fullScreenCover(isPresented: .constant(true)) {
                 IngredientHostView(title: "Add new ingredient", buttonTitle: "Add manually",
-                    saveHandler: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken),
+                                   saveHandler: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken, dataManager: DataManager.preview),
                     pickerViewModel: IngredientPickerViewModel())
             }
             

--- a/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
+++ b/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
@@ -37,7 +37,7 @@ struct IngredientHostView: View {
             .buttonStyle(.borderedProminent)
         }
         .sheet(isPresented: $addNewIngredient) {
-            IngredientEditorView { ingredientToSave in
+            IngredientEditorView(viewModel: IngredientEditorViewModel()) { ingredientToSave in
                 // assign ingredient to some value - this is a function already
                 saveHandler.addIngredient(ingredientToSave, pickerViewModel.originalSearchTerm)
                 DispatchQueue.main.async {

--- a/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
+++ b/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
@@ -59,17 +59,24 @@ struct IngredientHostView: View {
 }
 
 struct IngredientHostView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            ZStack {
+    private struct PreviewContainer: View {
+        @StateObject private var container: Container = .init()
+        var body: some View {
+            NavigationView {
+                ZStack {
+                  // Background
+                }
+                .fullScreenCover(isPresented: .constant(true)) {
+                    IngredientHostView(title: "Add new ingredient", buttonTitle: "Add manually",
+                                       saveHandler: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                                                    dataManager: container.dataManager),
+                                       pickerViewModel: IngredientPickerViewModel(networkController: container.networkController))
+                }
                 
             }
-            .fullScreenCover(isPresented: .constant(true)) {
-                IngredientHostView(title: "Add new ingredient", buttonTitle: "Add manually",
-                                   saveHandler: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken, dataManager: DataManager.preview),
-                    pickerViewModel: IngredientPickerViewModel())
-            }
-            
         }
+    }
+    static var previews: some View {
+        PreviewContainer()
     }
 }

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
@@ -17,7 +17,7 @@ struct RecipeCreatorHostView: View, KeyboardReadable {
         case confirmation
     }
     
-    @StateObject private var viewModel: RecipeCreatorViewModelProtocol = RecipeCreatorViewModel()
+    @StateObject private var viewModel: RecipeCreatorViewModelProtocol
     @State private var displayedStage: Stage
     @State private var processStage: Stage
     @State private var isShowingStageControls: Bool = true
@@ -30,7 +30,8 @@ struct RecipeCreatorHostView: View, KeyboardReadable {
             removal: .move(edge: .leading))
     }()
     
-    init(includeWebLink: Bool = false, path: Binding<NavigationPath>) {
+    init(viewModel: RecipeCreatorViewModelProtocol, path: Binding<NavigationPath>, includeWebLink: Bool = false) {
+        self._viewModel = StateObject.init(wrappedValue: viewModel)
         self.includeWebLink = includeWebLink
         self._path = path
         
@@ -148,6 +149,7 @@ struct RecipeCreatorHostView: View, KeyboardReadable {
             .padding(.horizontal, 10)
         }
     }
+    
 // MARK: COMPUTED PROPERTIES
     var isDisplayingPreviousStage: Bool {
         guard let displayedStageIndex = Stage.allCases.firstIndex(of: displayedStage),
@@ -239,9 +241,19 @@ extension RecipeCreatorHostView {
 }
 
 struct RecipeCreatorHostView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            RecipeCreatorHostView(includeWebLink: true ,path: .constant(NavigationPath()))
+    struct ContainerView: View {
+        @StateObject private var container: Container = .init()
+        var body: some View {
+            NavigationStack {
+                RecipeCreatorHostView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager,
+                                                                        networkController: container.networkController),
+                                      path: .constant(NavigationPath()),
+                                      includeWebLink: true)
+            }
+            .environmentObject(container)
         }
+    }
+    static var previews: some View {
+        ContainerView()
     }
 }

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorParserView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorParserView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeCreatorParserView: View {
-    
+    @EnvironmentObject private var container: Container
     @ObservedObject var viewModel: RecipeCreatorViewModelProtocol
     var saveHandler: IngredientSaveHandler
     
@@ -26,6 +26,7 @@ struct RecipeCreatorParserView: View {
                                     saveHandler: saveHandler,
                                     pickerViewModel:
                                         IngredientPickerViewModel(
+                                            networkController: container.networkController,
                                             ingredients: parsedIngredients,
                                             searchTerm: input))
                                 
@@ -37,6 +38,7 @@ struct RecipeCreatorParserView: View {
                                     saveHandler: saveHandler,
                                     pickerViewModel:
                                         IngredientPickerViewModel(
+                                            networkController: container.networkController,
                                             ingredients: [[]],
                                             searchTerm: input))
                             }
@@ -76,8 +78,7 @@ struct RecipeCreatorParserView: View {
 
 struct RecipeCreatorParserView_Previews: PreviewProvider {
     
-    class PreviewViewModel: RecipeCreatorViewModelProtocol {
-        
+    private class PreviewViewModel: RecipeCreatorViewModelProtocol {
         override init() {
             super.init()
             self.ingredientsNLArray = ["1 cup of rice", "1 chicken breast", "2 cups of broccoli florets", "This ingredient failed to parse"]
@@ -98,18 +99,15 @@ struct RecipeCreatorParserView_Previews: PreviewProvider {
         }
     } // END OF CLASS
     
-    class PreviewSaveHandler: IngredientSaveHandler {
-        
-        
+    private class PreviewSaveHandler: IngredientSaveHandler {
         func addIngredient(_: Ingredient, _: String?) {
             // do nothing
         }
-        
-        
     }
     static var previews: some View {
         NavigationStack {
             RecipeCreatorParserView(viewModel: PreviewViewModel(), saveHandler: PreviewSaveHandler())
         }
+        .environmentObject(Container())
     }
 }

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
@@ -195,9 +195,16 @@ struct RecipeCreatorView: View {
 
 
 struct RecipeCreatorView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            RecipeCreatorView(viewModel: RecipeCreatorViewModel())
+    struct PreviewContainer: View {
+        @StateObject private var container: Container = .init()
+        var body: some View {
+            NavigationView {
+                RecipeCreatorView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager, networkController: container.networkController))
+                    .environmentObject(container)
+            }
         }
+    }
+    static var previews: some View {
+        PreviewContainer()
     }
 }

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorWebLinkView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorWebLinkView.swift
@@ -30,9 +30,16 @@ struct RecipeCreatorWebLinkView: View {
 }
 
 struct RecipeCreatorWebLinkView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            RecipeCreatorWebLinkView(viewModel: RecipeCreatorViewModel())
+    struct PreviewContainer: View {
+        @StateObject private var container: Container = .init()
+        var body: some View {
+            NavigationView {
+                RecipeCreatorWebLinkView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager, networkController: container.networkController))
+                    .environmentObject(container)
+            }
         }
+    }
+    static var previews: some View {
+        PreviewContainer()
     }
 }

--- a/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
+++ b/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
@@ -15,7 +15,7 @@ struct RecipeListTabView: View {
         case addingNewRecipeWeb
         case showingRecipeDetail(Recipe)
     }
-    
+    @EnvironmentObject private var container: Container
     @StateObject private var viewModel: RecipeListViewModel
     @State private var path = NavigationPath()
     
@@ -32,11 +32,16 @@ struct RecipeListTabView: View {
             .navigationDestination(for: NavigationState.self) { state in
                 switch state {
                 case .showingRecipeDetailEdit(let recipe):
-                    RecipeHostView(isEditing: true, recipe: recipe, path: $path)
+                    RecipeHostView(viewModel: RecipeViewModel(recipe: recipe,
+                                                              dataManager: container.dataManager),
+                                   isEditing: true,
+                                   path: $path)
                 case .addingNewRecipeText:
                     RecipeCreatorHostView(path: $path)
                 case .showingRecipeDetail(let recipe):
-                    RecipeHostView(isEditing: false, recipe: recipe, path: $path)
+                    RecipeHostView(viewModel: RecipeViewModel(recipe: recipe,
+                                                              dataManager: container.dataManager),
+                                   path: $path)
                 case .addingNewRecipeWeb:
                     RecipeCreatorHostView(includeWebLink: true, path: $path)
                 }
@@ -48,5 +53,6 @@ struct RecipeListTabView: View {
 struct RecipeListTabView_Previews: PreviewProvider {
     static var previews: some View {
         RecipeListTabView(viewModel: RecipeListViewModel(dataManager: .preview))
+            .environmentObject(Container())
     }
 }

--- a/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
+++ b/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
@@ -31,19 +31,25 @@ struct RecipeListTabView: View {
             //MARK: NAVIGATION DESTINATIONS
             .navigationDestination(for: NavigationState.self) { state in
                 switch state {
+                case .showingRecipeDetail(let recipe):
+                    RecipeHostView(viewModel: RecipeViewModel(recipe: recipe,
+                                                              dataManager: container.dataManager),
+                                   path: $path)
                 case .showingRecipeDetailEdit(let recipe):
                     RecipeHostView(viewModel: RecipeViewModel(recipe: recipe,
                                                               dataManager: container.dataManager),
                                    isEditing: true,
                                    path: $path)
                 case .addingNewRecipeText:
-                    RecipeCreatorHostView(path: $path)
-                case .showingRecipeDetail(let recipe):
-                    RecipeHostView(viewModel: RecipeViewModel(recipe: recipe,
-                                                              dataManager: container.dataManager),
-                                   path: $path)
+                    RecipeCreatorHostView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager,
+                                                                            networkController: container.networkController),
+                                          path: $path)
+                
                 case .addingNewRecipeWeb:
-                    RecipeCreatorHostView(includeWebLink: true, path: $path)
+                    RecipeCreatorHostView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager,
+                                                                            networkController: container.networkController),
+                                          path: $path,
+                                          includeWebLink: true)
                 }
             }
         }

--- a/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
+++ b/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
@@ -19,7 +19,7 @@ struct RecipeListTabView: View {
     @StateObject private var viewModel: RecipeListViewModel
     @State private var path = NavigationPath()
     
-    public init(viewModel: RecipeListViewModel = RecipeListViewModel()) {
+    public init(viewModel: RecipeListViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
     

--- a/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import PhotosUI
 
 struct RecipeEditorView: View {
-    
+    @EnvironmentObject private var container: Container
     @ObservedObject var viewModel: RecipeViewModel
-    @State var isAddingNewIngredient: Bool = false
+    @State private var isAddingNewIngredient: Bool = false
     
     var body: some View {
         List {
@@ -36,7 +36,10 @@ struct RecipeEditorView: View {
             }
         }
         .fullScreenCover(isPresented: $isAddingNewIngredient) {
-            IngredientHostView(title: "Add new ingredient", buttonTitle: "Add manually", saveHandler: viewModel, pickerViewModel: IngredientPickerViewModel())
+            IngredientHostView(title: "Add new ingredient", 
+                               buttonTitle: "Add manually",
+                               saveHandler: viewModel,
+                               pickerViewModel: IngredientPickerViewModel(networkController: container.networkController))
         }
     }//END OF BODY
     
@@ -190,11 +193,18 @@ struct RecipeEditorView: View {
 }
 
 struct RecipeEditorView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            RecipeEditorView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
-                                                        dataManager: DataManager.preview)
-            )
+    private struct ContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            NavigationView {
+                RecipeEditorView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                                            dataManager: container.dataManager)
+                )
+            }
+            .environmentObject(container)
         }
+    }
+    static var previews: some View {
+        ContainerView()
     }
 }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
@@ -192,7 +192,9 @@ struct RecipeEditorView: View {
 struct RecipeEditorView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            RecipeEditorView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken))
+            RecipeEditorView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                                        dataManager: DataManager.preview)
+            )
         }
     }
 }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
@@ -13,8 +13,10 @@ struct RecipeHostView: View {
     @StateObject var viewModel: RecipeViewModel
     @Binding var path: NavigationPath
     
-    init(isEditing: Bool, recipe: Recipe, dataManager: DataManager = DataManager.shared, path: Binding<NavigationPath>) {
-        self._viewModel = StateObject(wrappedValue: RecipeViewModel(recipe: recipe, dataManager: dataManager))
+    init(viewModel: RecipeViewModel,
+         isEditing: Bool = false,
+         path: Binding<NavigationPath>) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
         self._path = path
         self.isEditing = isEditing
     }
@@ -71,11 +73,9 @@ struct RecipeHostView: View {
 struct RecipeHostView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            RecipeHostView(
-                isEditing: false,
-                recipe: SampleData.recipieCilantroLimeChicken,
-                dataManager: .preview,
-                path:.constant(NavigationPath())
+            RecipeHostView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                                      dataManager: DataManager.preview),
+                           path: .constant(NavigationPath())
             )
         }
     }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
@@ -71,12 +71,20 @@ struct RecipeHostView: View {
 }
 
 struct RecipeHostView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            RecipeHostView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
-                                                      dataManager: DataManager.preview),
-                           path: .constant(NavigationPath())
-            )
+    
+    private struct PreviewContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            NavigationView {
+                RecipeHostView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                                          dataManager: container.dataManager),
+                               path: .constant(NavigationPath())
+                )
+            }
         }
+    }
+    
+    static var previews: some View {
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
@@ -18,51 +18,49 @@ struct RecipeView: View {
                 .ignoresSafeArea()
             
             //Content layer
-                List {
-
-                    Section {
-                        titleBanner
-                            .listRowInsets(EdgeInsets())
-                        tagChipView
-                            .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
-                        HStack {
-                            Spacer()
-                            RecipeSummaryView(timePreparingInMinutes: viewModel.recipe.timePreparingInMinutes ?? 0,
-                                              timeCookingInMinutes: viewModel.recipe.timeCookingInMinutes ?? 0,
-                                              timeWaitingInMinues: viewModel.recipe.timeWaitingInMinutes ?? 0,
-                                              timeTotalInMinutes: viewModel.totalTimeCookingInMinutes,
-                                              cal: viewModel.recipe.nutritionData.calories,
-                                              proteinInGrams: viewModel.recipe.nutritionData.protein,
-                                              fatInGrams: viewModel.recipe.nutritionData.fat,
-                                              carbInGrams: viewModel.recipe.nutritionData.carb,
-                                              servings: viewModel.recipe.servings,
-                                              format: "%.0f")
-                            Spacer()
-                        }
-                    }
-                    .listRowSeparator(.hidden)
-                    
-                    
-                    Section("Ingredients:") {
-                        ForEach(viewModel.recipe.ingredients) {
-                            i in
-                            HStack {
-                                Text(i.food.name)
-                                Spacer()
-                                Text(String(format: "%.2f",i.quantity))
-                                Text(i.unitOfMeasure)
-                            }
-                            
-                        }
-                    }
-                    Section("Instructions") {
-                        ForEach($viewModel.recipe.instructions) { instruction in
-                            InstructionRowView(instructionText: instruction.text, step: instruction.step.wrappedValue, editable: false)
-                        }
+            List {
+                Section {
+                    titleBanner
+                        .listRowInsets(EdgeInsets())
+                    tagChipView
+                        .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+                    HStack {
+                        Spacer()
+                        RecipeSummaryView(timePreparingInMinutes: viewModel.recipe.timePreparingInMinutes ?? 0,
+                                          timeCookingInMinutes: viewModel.recipe.timeCookingInMinutes ?? 0,
+                                          timeWaitingInMinues: viewModel.recipe.timeWaitingInMinutes ?? 0,
+                                          timeTotalInMinutes: viewModel.totalTimeCookingInMinutes,
+                                          cal: viewModel.recipe.nutritionData.calories,
+                                          proteinInGrams: viewModel.recipe.nutritionData.protein,
+                                          fatInGrams: viewModel.recipe.nutritionData.fat,
+                                          carbInGrams: viewModel.recipe.nutritionData.carb,
+                                          servings: viewModel.recipe.servings,
+                                          format: "%.0f")
+                        Spacer()
                     }
                 }
-                .listStyle(.inset)
-                .ignoresSafeArea(edges: .top)
+                .listRowSeparator(.hidden)
+                
+                Section("Ingredients:") {
+                    ForEach(viewModel.recipe.ingredients) {
+                        i in
+                        HStack {
+                            Text(i.food.name)
+                            Spacer()
+                            Text(String(format: "%.2f",i.quantity))
+                            Text(i.unitOfMeasure)
+                        }
+                        
+                    }
+                }
+                Section("Instructions") {
+                    ForEach($viewModel.recipe.instructions) { instruction in
+                        InstructionRowView(instructionText: instruction.text, step: instruction.step.wrappedValue, editable: false)
+                    }
+                }
+            }
+            .listStyle(.inset)
+            .ignoresSafeArea(edges: .top)
         }
     }
     
@@ -90,25 +88,32 @@ struct RecipeView: View {
     }
     
     var tagChipView: some View {
-        
-        
         ChipView(tags: $viewModel.recipe.tags, avaliableWidth: UIScreen.main.bounds.width - 20, alignment: .leading) { tag in
-                    Text(tag.text)
-                        .foregroundColor(.white)
-                        .padding(.horizontal)
-                        .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
-                        .background(
-                            Capsule()
-                            .foregroundColor(.blue))
-                }
-         
+            Text(tag.text)
+                .foregroundColor(.white)
+                .padding(.horizontal)
+                .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+                .background(
+                    Capsule()
+                        .foregroundColor(.blue))
+        }
     }
 }
 
 struct RecipieView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            RecipeView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken, dataManager: DataManager.preview))
+    private struct PreviewContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            NavigationView {
+                RecipeView(viewModel: 
+                            RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,
+                                            dataManager: container.dataManager))
+            }
+            .environmentObject(container)
         }
+    }
+    
+    static var previews: some View {
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
@@ -108,7 +108,7 @@ struct RecipeView: View {
 struct RecipieView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            RecipeView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken))
+            RecipeView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken, dataManager: DataManager.preview))
         }
     }
 }

--- a/GymMealPrep/Recipe/ViewModels/IngredientEditorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/IngredientEditorViewModel.swift
@@ -34,7 +34,7 @@ class IngredientEditorViewModelProtocol: ObservableObject {
             self.lockNutritionValues = true
             self.isEditingIngredient = true
         } else {
-            self.draftIngredient = Ingredient() // TODO: this is concrete so i have to check how to set it to the same type - should it be generic protocol?
+            self.draftIngredient = Ingredient()
             self.lockNutritionValues = false
             self.isEditingIngredient = false
         }

--- a/GymMealPrep/Recipe/ViewModels/IngredientPickerViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/IngredientPickerViewModel.swift
@@ -33,9 +33,10 @@ class IngredientPickerViewModel: IngredientPickerViewModelProtocol {
     let originalSearchTerm: String?
     
     var subscriptions = Set<AnyCancellable>()
-    let edamamLogicController: EdamamLogicController = EdamamLogicController(networkController: NetworkController())
+    let edamamLogicController: EdamamLogicController
     
-    init(ingredients: [[Ingredient]] = [[]], searchTerm: String = String()){
+    init(networkController: NetworkController, ingredients: [[Ingredient]] = [[]], searchTerm: String = String()){
+        self.edamamLogicController = EdamamLogicController(networkController: networkController)
         self.searchTerm = searchTerm
         if !searchTerm.isEmpty {
             self.originalSearchTerm = searchTerm

--- a/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeCreatorViewModel.swift
@@ -17,9 +17,9 @@ class RecipeCreatorViewModel: RecipeCreatorViewModelProtocol {
     let edamamLogicController: EdamamLogicControllerProtocol
     let webLinkLogicController: WebLinkLogicController
     
-    init(dataManager: DataManager = .shared) {
+    init(dataManager: DataManager, networkController: NetworkController) {
         self.dataManager = dataManager
-        self.networkController = NetworkController()
+        self.networkController = networkController
         self.edamamLogicController = EdamamLogicController(networkController: networkController)
         self.webLinkLogicController = WebLinkLogicController(networkController: networkController)
         super.init()

--- a/GymMealPrep/Recipe/ViewModels/RecipeListViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeListViewModel.swift
@@ -19,7 +19,7 @@ class RecipeListViewModel: ObservableObject {
     }
     
     
-    init(dataManager: DataManager = DataManager.shared) {
+    init(dataManager: DataManager) {
         
         self.dataManager = dataManager
         
@@ -29,11 +29,6 @@ class RecipeListViewModel: ObservableObject {
         }.store(in: &subscriptions)
     }
     
-//    func createRecipeViewModel(recipe: Recipe) -> RecipeViewModel {
-//        let recipeDataManager = dataManager as RecipeDataManagerProtocol
-//        return RecipeViewModel(recipe: recipe, dataManager: recipeDataManager)
-//    }
-    
     func deleteRecipe(atOffsets offsets: IndexSet) {
         var recipiesToDelete = [Recipe]()
         offsets.forEach { i in
@@ -42,9 +37,5 @@ class RecipeListViewModel: ObservableObject {
         for recipe in recipiesToDelete {
             dataManager.delete(recipe: recipe)
         }
-    }
-    
-    func provideDataManagerType() -> DataManager {
-        return dataManager
     }
 }

--- a/GymMealPrep/Recipe/ViewModels/RecipeViewModel.swift
+++ b/GymMealPrep/Recipe/ViewModels/RecipeViewModel.swift
@@ -31,7 +31,6 @@ class RecipeViewModel: ObservableObject {
         return (recipe.timeCookingInMinutes ?? 0)  + (recipe.timePreparingInMinutes ?? 0) + (recipe.timeWaitingInMinutes ?? 0)
     }
     
-    
     @Published var timePreparingInMinutes: String
     @Published var timeCookingInMinutes: String
     @Published var timeWaitingInMinutes: String
@@ -51,7 +50,7 @@ class RecipeViewModel: ObservableObject {
     }
     
     
-    init(recipe: Recipe, dataManager: RecipeDataManagerProtocol = DataManager.shared) {
+    init(recipe: Recipe, dataManager: RecipeDataManagerProtocol) {
         self.recipe = recipe
         if let timePreparing = recipe.timePreparingInMinutes {
             self.timePreparingInMinutes = "\(timePreparing)"

--- a/GymMealPrep/Settings/SettingsDetailView.swift
+++ b/GymMealPrep/Settings/SettingsDetailView.swift
@@ -203,16 +203,23 @@ extension SettingsDetailView {
 }
 
 struct SettingsDetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            SettingsDetailView(
-                title: "Preview",
-                viewModel: SettingsDetailViewModel(
-                    settingStore: SettingStore(),
-                    settingModels: [
-                        SettingModel(setting: .mealNames, valueText: nil, tipText: "Preview tooltip")
-                    ])
-            )
+    private struct PreviewContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            NavigationStack {
+                SettingsDetailView(
+                    title: "Preview",
+                    viewModel: SettingsDetailViewModel(
+                        settingStore: container.settingStore,
+                        settingModels: [
+                            SettingModel(setting: .mealNames, valueText: nil, tipText: "Preview tooltip")
+                        ])
+                )
+            }
+            .environmentObject(container)
         }
+    }
+    static var previews: some View {
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/Settings/SettingsListView.swift
+++ b/GymMealPrep/Settings/SettingsListView.swift
@@ -64,9 +64,18 @@ struct SettingsListView: View {
 } // END OF STRUCT
 
 struct SettingsListView_Previews: PreviewProvider {
-    struct Container: View {
-        @StateObject private var vm = SettingsViewModel()
-        @State private var path = NavigationPath()
+    
+    private struct PreviewContainerView: View {
+        @StateObject private var container: Container
+        @StateObject private var vm: SettingsViewModel
+        @State private var path: NavigationPath
+        
+        init() {
+            let tempContainer = Container()
+            self._container = StateObject(wrappedValue: tempContainer)
+            self._vm = StateObject(wrappedValue: SettingsViewModel(settingStore: tempContainer.settingStore))
+            self._path = State(wrappedValue: NavigationPath())
+        }
         var body: some View {
             NavigationStack(path: $path) {
                 SettingsListView(viewModel: vm, path: $path)
@@ -75,7 +84,7 @@ struct SettingsListView_Previews: PreviewProvider {
     }
     
     static var previews: some View {
-        Container()
+        PreviewContainerView()
     }
 }
 

--- a/GymMealPrep/Settings/SettingsMacroTargetsView.swift
+++ b/GymMealPrep/Settings/SettingsMacroTargetsView.swift
@@ -145,18 +145,26 @@ struct SettingsMacroTargetsView: View {
 }
 
 struct SwiftUIView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack{
-            SettingsMacroTargetsView(title: "Macro targets",
-                                     vm: SettingsDetailViewModel(
-                                        settingStore: SettingStore(),
-                                        settingModels: [
-                                            SettingModel(setting: .macroTargetProtein, tipText: nil),
-                                            SettingModel(setting: .macroTargetFat, tipText: nil),
-                                            SettingModel(setting: .macroTargetCarb, tipText: nil),
-                                        ]
-                                     )
-            )
+    
+    private struct PreviewContainerView: View {
+        @StateObject private var container = Container()
+        
+        var body: some View {
+            NavigationStack{
+                SettingsMacroTargetsView(title: "Macro targets",
+                                         vm: SettingsDetailViewModel(
+                                            settingStore: container.settingStore,
+                                            settingModels: [
+                                                SettingModel(setting: .macroTargetProtein, tipText: nil),
+                                                SettingModel(setting: .macroTargetFat, tipText: nil),
+                                                SettingModel(setting: .macroTargetCarb, tipText: nil),
+                                            ]
+                                         )
+                )
+            }
         }
+    }
+    static var previews: some View {
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/Settings/SettingsTabView.swift
+++ b/GymMealPrep/Settings/SettingsTabView.swift
@@ -7,10 +7,6 @@
 
 import SwiftUI
 
-class Container: ObservableObject {
-    var settingStore: SettingStore = .init()
-}
-
 struct SettingsTabView: View {
     
     @EnvironmentObject private var container: Container

--- a/GymMealPrep/Settings/SettingsTabView.swift
+++ b/GymMealPrep/Settings/SettingsTabView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SettingsTabView: View {
     
     @EnvironmentObject private var container: Container
-    @StateObject private var viewModel = SettingsViewModel()
+    @StateObject private var viewModel: SettingsViewModel
     @State private var path = NavigationPath()
     
     init(viewModel: SettingsViewModel) {
@@ -52,8 +52,9 @@ struct SettingsTabView: View {
 
 struct SettingsTabView_Previews: PreviewProvider {
     
-    struct PreviewContainer: View {
+    private struct PreviewContainerView: View {
         @StateObject private var container: Container = .init()
+        
         var body: some View {
             SettingsTabView(viewModel: SettingsViewModel(settingStore: container.settingStore))
                 .environmentObject(container)
@@ -61,6 +62,6 @@ struct SettingsTabView_Previews: PreviewProvider {
     }
     
     static var previews: some View {
-        PreviewContainer()
+        PreviewContainerView()
     }
 }

--- a/GymMealPrep/Settings/SettingsViewModel.swift
+++ b/GymMealPrep/Settings/SettingsViewModel.swift
@@ -14,7 +14,7 @@ class SettingsViewModel: ObservableObject {
     @Published var settings: [SettingSection] = []
     private var cancellables: Set<AnyCancellable> = .init()
     
-    init(settingStore: SettingStore = SettingStore()) {
+    init(settingStore: SettingStore) {
         self.settingStore = settingStore
         self.settings = createSettingSections()
         

--- a/GymMealPrepTests/RecipeCreatorViewModelTests.swift
+++ b/GymMealPrepTests/RecipeCreatorViewModelTests.swift
@@ -43,7 +43,7 @@ final class RecipeCreatorViewModelTests: XCTestCase {
     let instructionEntryStringWithNumbersOnly = "1 Instruction step 1\n2 Instruction step 2\n3 Instruction step 3\n"
     
     override func setUp() {
-        sut = RecipeCreatorViewModel()
+        sut = RecipeCreatorViewModel(dataManager: DataManager.testing, networkController: NetworkController())
     }
 
     override func tearDown() {


### PR DESCRIPTION
In this PR a simple root container class was created to handle and provide instance of services to views and view models that need them for construction. Following classes are in the container:
- data manager
- network controller
- setting store 

Container access was implemented in all of the views and view models. Default values are removed from initialisers to prevent non-injected objects. 