### PR TITLE
Add testing and preview configuration to container

### DIFF
--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -427,6 +427,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		D634BD422AF1A62F001BEAEE /* SettingStore */ = {
+			isa = PBXGroup;
+			children = (
+				D6705A642AC4A3C100CF0BA9 /* SettingsStore.swift */,
+			);
+			path = SettingStore;
+			sourceTree = "<group>";
+		};
 		D634FF7A29FD42F50034B950 = {
 			isa = PBXGroup;
 			children = (
@@ -468,7 +476,7 @@
 				D634FFB229FD44330034B950 /* PresistanceContainer.swift */,
 				D61E3A672A9A73A400AB2527 /* Settings */,
 				D61E3A652A9A729400AB2527 /* K.swift */,
-				D6705A642AC4A3C100CF0BA9 /* SettingsStore.swift */,
+				D634BD422AF1A62F001BEAEE /* SettingStore */,
 				D6155FFF2AEB0BEE0043BDB6 /* Container.swift */,
 				D634FF8829FD42F50034B950 /* ContentView.swift */,
 				D634FFB629FD52100034B950 /* Model.xcdatamodeld */,

--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		D680C3392A140A2F002070DF /* EndpointProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D680C3382A140A2F002070DF /* EndpointProtocol.swift */; };
 		D6866BBD2A60931600A5BAD8 /* KeyboardReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6866BBC2A60931600A5BAD8 /* KeyboardReadable.swift */; };
 		D68D5B652A4CAE7C00B0791E /* DataManager+MealPlanMOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68D5B642A4CAE7C00B0791E /* DataManager+MealPlanMOTests.swift */; };
+		D691E6282AF2F1D20065ECCB /* TestSettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D691E6272AF2F1D20065ECCB /* TestSettingStore.swift */; };
+		D691E62A2AF2F58E0065ECCB /* ProductionSettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D691E6292AF2F58E0065ECCB /* ProductionSettingStore.swift */; };
 		D692EEE72A12879400680CCC /* EdamamParserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D692EEE62A12879400680CCC /* EdamamParserResponse.swift */; };
 		D692EEE92A129A6D00680CCC /* SampleParserJson.json in Resources */ = {isa = PBXBuildFile; fileRef = D692EEE82A129A6D00680CCC /* SampleParserJson.json */; };
 		D694E3F52A057D370077E72F /* FoodMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D694E3F32A057D370077E72F /* FoodMO+CoreDataClass.swift */; };
@@ -265,6 +267,8 @@
 		D680C3382A140A2F002070DF /* EndpointProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointProtocol.swift; sourceTree = "<group>"; };
 		D6866BBC2A60931600A5BAD8 /* KeyboardReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardReadable.swift; sourceTree = "<group>"; };
 		D68D5B642A4CAE7C00B0791E /* DataManager+MealPlanMOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+MealPlanMOTests.swift"; sourceTree = "<group>"; };
+		D691E6272AF2F1D20065ECCB /* TestSettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSettingStore.swift; sourceTree = "<group>"; };
+		D691E6292AF2F58E0065ECCB /* ProductionSettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionSettingStore.swift; sourceTree = "<group>"; };
 		D692EEE62A12879400680CCC /* EdamamParserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdamamParserResponse.swift; sourceTree = "<group>"; };
 		D692EEE82A129A6D00680CCC /* SampleParserJson.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SampleParserJson.json; sourceTree = "<group>"; };
 		D694E3F32A057D370077E72F /* FoodMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoodMO+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -435,6 +439,8 @@
 			isa = PBXGroup;
 			children = (
 				D6705A642AC4A3C100CF0BA9 /* SettingsStore.swift */,
+				D691E6292AF2F58E0065ECCB /* ProductionSettingStore.swift */,
+				D691E6272AF2F1D20065ECCB /* TestSettingStore.swift */,
 				D655E84B2AF1B85F00F6C2F1 /* PreviewSettingStore.swift */,
 				D655E8492AF1B74100F6C2F1 /* SettingStoreable.swift */,
 			);
@@ -1098,6 +1104,7 @@
 				D674FB222A518F140066F667 /* MealPlanEditorSheetView.swift in Sources */,
 				D69E224A2A1FEA3E00F5EF93 /* TextFieldModifier.swift in Sources */,
 				D63AFA222A01238300574FE0 /* RecipeEditorView.swift in Sources */,
+				D691E6282AF2F1D20065ECCB /* TestSettingStore.swift in Sources */,
 				D6C3405A29FFCE03003F6E06 /* SampleData.swift in Sources */,
 				D694E4072A05824A0077E72F /* IngredientMO+CoreDataClass.swift in Sources */,
 				D65E4C9D2A40EB23008C7A2F /* MealMO+CoreDataClass.swift in Sources */,
@@ -1129,6 +1136,7 @@
 				D634FFB829FD52100034B950 /* Model.xcdatamodeld in Sources */,
 				D634FF8929FD42F50034B950 /* ContentView.swift in Sources */,
 				D6C3405029FD8085003F6E06 /* Instruction.swift in Sources */,
+				D691E62A2AF2F58E0065ECCB /* ProductionSettingStore.swift in Sources */,
 				D6D77A712A2339B7006D63B5 /* RecipeCreatorParserView.swift in Sources */,
 				D61E3A6B2A9A750700AB2527 /* SettingsViewModel.swift in Sources */,
 				D674FB242A5194D60066F667 /* RecipePickerView.swift in Sources */,

--- a/GymMealPrep.xcodeproj/project.pbxproj
+++ b/GymMealPrep.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		D64D95082A114DC50080CD70 /* NetworkProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64D95072A114DC50080CD70 /* NetworkProtocol.swift */; };
 		D64D950E2A116EE80080CD70 /* IngredientPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64D950D2A116EE80080CD70 /* IngredientPickerView.swift */; };
 		D64E04A42A8D4B3400D72A64 /* RecipeInputParserEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64E04A32A8D4B3400D72A64 /* RecipeInputParserEngineTests.swift */; };
+		D655E84A2AF1B74100F6C2F1 /* SettingStoreable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D655E8492AF1B74100F6C2F1 /* SettingStoreable.swift */; };
+		D655E84C2AF1B85F00F6C2F1 /* PreviewSettingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D655E84B2AF1B85F00F6C2F1 /* PreviewSettingStore.swift */; };
 		D655E8C22A4CF813004D5079 /* MealPlanTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D655E8C12A4CF813004D5079 /* MealPlanTabViewModel.swift */; };
 		D655E8C42A4D0051004D5079 /* MealPlanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D655E8C32A4D0051004D5079 /* MealPlanViewModel.swift */; };
 		D65713542A93AD4C0063BA8C /* ParserEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65713532A93AD4C0063BA8C /* ParserEngine.swift */; };
@@ -234,6 +236,8 @@
 		D64D95072A114DC50080CD70 /* NetworkProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtocol.swift; sourceTree = "<group>"; };
 		D64D950D2A116EE80080CD70 /* IngredientPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientPickerView.swift; sourceTree = "<group>"; };
 		D64E04A32A8D4B3400D72A64 /* RecipeInputParserEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeInputParserEngineTests.swift; sourceTree = "<group>"; };
+		D655E8492AF1B74100F6C2F1 /* SettingStoreable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStoreable.swift; sourceTree = "<group>"; };
+		D655E84B2AF1B85F00F6C2F1 /* PreviewSettingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSettingStore.swift; sourceTree = "<group>"; };
 		D655E8C12A4CF813004D5079 /* MealPlanTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlanTabViewModel.swift; sourceTree = "<group>"; };
 		D655E8C32A4D0051004D5079 /* MealPlanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealPlanViewModel.swift; sourceTree = "<group>"; };
 		D65713532A93AD4C0063BA8C /* ParserEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserEngine.swift; sourceTree = "<group>"; };
@@ -431,6 +435,8 @@
 			isa = PBXGroup;
 			children = (
 				D6705A642AC4A3C100CF0BA9 /* SettingsStore.swift */,
+				D655E84B2AF1B85F00F6C2F1 /* PreviewSettingStore.swift */,
+				D655E8492AF1B74100F6C2F1 /* SettingStoreable.swift */,
 			);
 			path = SettingStore;
 			sourceTree = "<group>";
@@ -1052,6 +1058,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D655E84C2AF1B85F00F6C2F1 /* PreviewSettingStore.swift in Sources */,
 				D648FC512A422F6300393AC3 /* MealPlan.swift in Sources */,
 				D614A0422A1D4FA700C55D34 /* IngredientEditorViewModel.swift in Sources */,
 				D6EF40572AC89F8E004365D8 /* SettingsDetailView.swift in Sources */,
@@ -1152,6 +1159,7 @@
 				D6E35C412A39D9DD00CB9E19 /* RecipeCreatorConfirmationView.swift in Sources */,
 				D69C21E72A46F95E002DE11A /* MealPlanRowView.swift in Sources */,
 				D6C3403D29FD763D003F6E06 /* Food.swift in Sources */,
+				D655E84A2AF1B74100F6C2F1 /* SettingStoreable.swift in Sources */,
 				D6C3404C29FD7FB9003F6E06 /* RecipeView.swift in Sources */,
 				D69C21E52A46F748002DE11A /* MealPlanEditorView.swift in Sources */,
 				D694E4052A05824A0077E72F /* InstructionMO+CoreDataClass.swift in Sources */,

--- a/GymMealPrep/Container.swift
+++ b/GymMealPrep/Container.swift
@@ -7,8 +7,44 @@
 
 import Foundation
 
+fileprivate enum ContainerType {
+    case production, test, preview
+}
+
 class Container: ObservableObject {
-    var settingStore: SettingStore = .init()
-    var dataManager: DataManager = .shared
-    var networkController: NetworkController = .init()
+    private(set) var settingStore: SettingStore = .init() // no protocol avaliable
+    private(set) var dataManager: DataManager = .shared // no protocol avaliable
+    private(set) var networkController: NetworkController // network protocol
+    
+    fileprivate init(type: ContainerType) {
+        switch type {
+        case .production:
+            self.settingStore = SettingStore()
+            self.dataManager = DataManager.shared
+            self.networkController = NetworkController()
+        case .test:
+            self.dataManager = DataManager.testing
+            //TODO: IMPLEMET TESTING ENVIRONMENT SETTING STORE AND NETWORK CONTROLLER
+            self.settingStore = SettingStore()
+            self.networkController = NetworkController()
+        case .preview:
+            self.dataManager = .preview
+            self.settingStore = SettingStore()
+            self.networkController = NetworkController()
+        }
+    }
+    
+    
+}
+
+struct ContainerFactory {
+    static func build() -> Container {
+        if ProcessInfo.processInfo.environment[K.previewEnvironmentFlagKey] == "1" {
+            return Container(type: .preview)
+        } else if CommandLine.arguments.contains(K.testingFlag){
+            return Container(type: .test)
+        } else {
+            return Container(type: .production)
+        }
+    }
 }

--- a/GymMealPrep/Container.swift
+++ b/GymMealPrep/Container.swift
@@ -12,24 +12,24 @@ fileprivate enum ContainerType {
 }
 
 class Container: ObservableObject {
-    private(set) var settingStore: SettingStore = .init() // no protocol avaliable
+    private(set) var settingStore: SettingStoreable // protocol-class avaliable
     private(set) var dataManager: DataManager = .shared // no protocol avaliable
     private(set) var networkController: NetworkController // network protocol
     
     fileprivate init(type: ContainerType) {
         switch type {
         case .production:
-            self.settingStore = SettingStore()
+            self.settingStore = ProductionSettingStore()
             self.dataManager = DataManager.shared
             self.networkController = NetworkController()
         case .test:
             self.dataManager = DataManager.testing
             //TODO: IMPLEMET TESTING ENVIRONMENT SETTING STORE AND NETWORK CONTROLLER
-            self.settingStore = SettingStore()
+            self.settingStore = TestSettingStore()
             self.networkController = NetworkController()
         case .preview:
             self.dataManager = .preview
-            self.settingStore = SettingStore()
+            self.settingStore = PreviewSettingStore()
             self.networkController = NetworkController()
         }
     }

--- a/GymMealPrep/ContentView.swift
+++ b/GymMealPrep/ContentView.swift
@@ -45,6 +45,6 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .environmentObject(Container())
+            .environmentObject(ContainerFactory.build())
     }
 }

--- a/GymMealPrep/GymMealPrepApp.swift
+++ b/GymMealPrep/GymMealPrepApp.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 @main
 struct GymMealPrepApp: App {
-    @StateObject private var container: Container = .init()
+    @StateObject private var container: Container = ContainerFactory.build()
+    
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/GymMealPrep/K.swift
+++ b/GymMealPrep/K.swift
@@ -15,4 +15,6 @@ struct K {
         static let macroTargetCarb = "macro-target-carb"
         static let theme = "theme"
     }
+    static let previewEnvironmentFlagKey = "XCODE_RUNNING_FOR_PREVIEWS"
+    static let testingFlag = "-test"
 }

--- a/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
+++ b/GymMealPrep/MealPlan/SubViews/MealPlanEditorSheetView.swift
@@ -63,7 +63,7 @@ struct MealPlanEditorSheetView_Previews: PreviewProvider {
                 .sheet(isPresented: .constant(true)) {
                     MealPlanEditorSheetView(saveHandler: PreviewSaveHandler(), navigationPath: .constant(NavigationPath()))
                 }
-                .environmentObject(Container())
+                .environmentObject(ContainerFactory.build())
         }
         
     }

--- a/GymMealPrep/MealPlan/SubViews/RecipePickerView.swift
+++ b/GymMealPrep/MealPlan/SubViews/RecipePickerView.swift
@@ -61,7 +61,7 @@ struct RecipePickerView_Previews: PreviewProvider {
     }
     
     private struct ContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         var body: some View {
             RecipePickerView(saveHandler: PreviewSaveHandler(),
                              viewModel: RecipePickerViewModel(dataManager: container.dataManager))

--- a/GymMealPrep/MealPlan/Views/MealPlanDetailView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanDetailView.swift
@@ -75,7 +75,7 @@ struct MealPlanDetailView_Previews: PreviewProvider {
         @State private var navigationPath: NavigationPath
         
         init() {
-            let container = Container()
+            let container = ContainerFactory.build()
             self._container = StateObject(wrappedValue: container)
             self._viewModel = StateObject(wrappedValue: .init(mealPlan: SampleData.sampleMealPlan,
                                                               dataManager: container.dataManager))

--- a/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanEditorView.swift
@@ -147,7 +147,7 @@ struct MealPlanEditorView_Previews: PreviewProvider {
         @State private var navigationPath: NavigationPath
         
         init() {
-            let container = Container()
+            let container = ContainerFactory.build()
             self._container = StateObject(wrappedValue: container)
             self._viewModel = StateObject(wrappedValue: MealPlanViewModel(mealPlan: SampleData.sampleMealPlan,
                                                                           dataManager: container.dataManager))

--- a/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
+++ b/GymMealPrep/MealPlan/Views/MealPlanHostView.swift
@@ -49,7 +49,7 @@ struct MealPlanHostView: View {
 
 struct MealPlanHostView_Previews: PreviewProvider {
     private struct PreviewContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         @State private var navPath = NavigationPath()
         var body: some View {
             NavigationStack {

--- a/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
+++ b/GymMealPrep/Recipe/IngredientViews/IngredientHostView.swift
@@ -60,7 +60,7 @@ struct IngredientHostView: View {
 
 struct IngredientHostView_Previews: PreviewProvider {
     private struct PreviewContainer: View {
-        @StateObject private var container: Container = .init()
+        @StateObject private var container: Container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 ZStack {

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorHostView.swift
@@ -242,7 +242,7 @@ extension RecipeCreatorHostView {
 
 struct RecipeCreatorHostView_Previews: PreviewProvider {
     struct ContainerView: View {
-        @StateObject private var container: Container = .init()
+        @StateObject private var container: Container = ContainerFactory.build()
         var body: some View {
             NavigationStack {
                 RecipeCreatorHostView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager,

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorParserView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorParserView.swift
@@ -108,6 +108,6 @@ struct RecipeCreatorParserView_Previews: PreviewProvider {
         NavigationStack {
             RecipeCreatorParserView(viewModel: PreviewViewModel(), saveHandler: PreviewSaveHandler())
         }
-        .environmentObject(Container())
+        .environmentObject(ContainerFactory.build())
     }
 }

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorView.swift
@@ -196,7 +196,7 @@ struct RecipeCreatorView: View {
 
 struct RecipeCreatorView_Previews: PreviewProvider {
     struct PreviewContainer: View {
-        @StateObject private var container: Container = .init()
+        @StateObject private var container: Container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 RecipeCreatorView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager, networkController: container.networkController))

--- a/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorWebLinkView.swift
+++ b/GymMealPrep/Recipe/RecipeCreatorViews/RecipeCreatorWebLinkView.swift
@@ -31,7 +31,7 @@ struct RecipeCreatorWebLinkView: View {
 
 struct RecipeCreatorWebLinkView_Previews: PreviewProvider {
     struct PreviewContainer: View {
-        @StateObject private var container: Container = .init()
+        @StateObject private var container: Container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 RecipeCreatorWebLinkView(viewModel: RecipeCreatorViewModel(dataManager: container.dataManager, networkController: container.networkController))

--- a/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
+++ b/GymMealPrep/Recipe/RecipeListViews/RecipeListTabView.swift
@@ -59,6 +59,6 @@ struct RecipeListTabView: View {
 struct RecipeListTabView_Previews: PreviewProvider {
     static var previews: some View {
         RecipeListTabView(viewModel: RecipeListViewModel(dataManager: .preview))
-            .environmentObject(Container())
+            .environmentObject(ContainerFactory.build())
     }
 }

--- a/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeEditorView.swift
@@ -194,7 +194,7 @@ struct RecipeEditorView: View {
 
 struct RecipeEditorView_Previews: PreviewProvider {
     private struct ContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 RecipeEditorView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,

--- a/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeHostView.swift
@@ -73,7 +73,7 @@ struct RecipeHostView: View {
 struct RecipeHostView_Previews: PreviewProvider {
     
     private struct PreviewContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 RecipeHostView(viewModel: RecipeViewModel(recipe: SampleData.recipieCilantroLimeChicken,

--- a/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
+++ b/GymMealPrep/Recipe/RecipeViews/RecipeView.swift
@@ -102,7 +102,7 @@ struct RecipeView: View {
 
 struct RecipieView_Previews: PreviewProvider {
     private struct PreviewContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         var body: some View {
             NavigationView {
                 RecipeView(viewModel: 

--- a/GymMealPrep/SettingStore/PreviewSettingStore.swift
+++ b/GymMealPrep/SettingStore/PreviewSettingStore.swift
@@ -13,36 +13,9 @@ class PreviewSettingStore: SettingStoreable {
         self.settings = {
             var result: [Setting : Any?] = .init()
             for setting in Setting.allCases {
-                result.updateValue(returnDefaultValue(for: setting), forKey: setting)
+                result.updateValue(SettingStoreable.provideDefaultValue(for: setting), forKey: setting)
             }
             return result
         }()
-    }
-    
-    private func returnDefaultValue(for setting: Setting) -> Any? {
-        switch setting {
-        case .calorieTarget:
-            return Double(3100)
-        case .macroTargetProtein:
-            return Double(180)
-        case .macroTargetFat:
-            return Double(60)
-        case .macroTargetCarb:
-            return Double(120)
-        case .numberOfMeals:
-            return Int(4)
-        case .mealNames:
-            return ["Breakfast", "Lunch", "Dinner", "Supper"]
-        case .groceries:
-            return Calendar.current.date(byAdding: .day, value: 3, to: Date())
-        case .nextPlan:
-            return Calendar.current.date(byAdding: .day, value: 10, to: Date())
-        case .units:
-            return Units.metric
-        case .theme:
-             return Theme.light
-        case .rateApp, .contactUs, .terms, .privacy, .apiReference:
-            return nil
-        }
     }
 }

--- a/GymMealPrep/SettingStore/PreviewSettingStore.swift
+++ b/GymMealPrep/SettingStore/PreviewSettingStore.swift
@@ -6,16 +6,27 @@
 //
 
 import Foundation
-
+///  PreviewSettingStore provides access and ability to modify user settings for the app. The use of this class is for previews. 
+///
+///  This class does not have presistent storage container and will not retain any changes between launch.
+///  While there is no presisten storage, as long as the instance is not deinitialize it will retain values, which are open to modification.
+///  Value for a given setting can be accessed by using an Setting enum instance as key to settings property dictionary and can be updated directly by updating the value in the settings dictionary.
 class PreviewSettingStore: SettingStoreable {
+    
     override init() {
         super.init()
-        self.settings = {
-            var result: [Setting : Any?] = .init()
-            for setting in Setting.allCases {
-                result.updateValue(SettingStoreable.provideDefaultValue(for: setting), forKey: setting)
-            }
-            return result
-        }()
+        self.settings = provideDefaultSettingsDictionary()
     }
+    
+    /// Reset settings values of this instance to default defined by SettingStoreable.
+    /// After calling this function the instance of store will be restored to it initial state.
+    override func resetStore() {
+        settings = provideDefaultSettingsDictionary()
+    }
+    
+    /// Provide a dictionary of setting and default values for the setting
+    private func provideDefaultSettingsDictionary() -> [Setting : Any?] {
+        return Dictionary(uniqueKeysWithValues: Setting.allCases.map({( $0, SettingStoreable.provideDefaultValue(for: $0))}))
+    }
+    
 }

--- a/GymMealPrep/SettingStore/PreviewSettingStore.swift
+++ b/GymMealPrep/SettingStore/PreviewSettingStore.swift
@@ -1,0 +1,48 @@
+//
+//  PreviewSettingStore.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 31/10/2023.
+//
+
+import Foundation
+
+class PreviewSettingStore: SettingStoreable {
+    override init() {
+        super.init()
+        self.settings = {
+            var result: [Setting : Any?] = .init()
+            for setting in Setting.allCases {
+                result.updateValue(returnDefaultValue(for: setting), forKey: setting)
+            }
+            return result
+        }()
+    }
+    
+    private func returnDefaultValue(for setting: Setting) -> Any? {
+        switch setting {
+        case .calorieTarget:
+            return Double(3100)
+        case .macroTargetProtein:
+            return Double(180)
+        case .macroTargetFat:
+            return Double(60)
+        case .macroTargetCarb:
+            return Double(120)
+        case .numberOfMeals:
+            return Int(4)
+        case .mealNames:
+            return ["Breakfast", "Lunch", "Dinner", "Supper"]
+        case .groceries:
+            return Calendar.current.date(byAdding: .day, value: 3, to: Date())
+        case .nextPlan:
+            return Calendar.current.date(byAdding: .day, value: 10, to: Date())
+        case .units:
+            return Units.metric
+        case .theme:
+             return Theme.light
+        case .rateApp, .contactUs, .terms, .privacy, .apiReference:
+            return nil
+        }
+    }
+}

--- a/GymMealPrep/SettingStore/ProductionSettingStore.swift
+++ b/GymMealPrep/SettingStore/ProductionSettingStore.swift
@@ -1,0 +1,14 @@
+//
+//  ProductionSettingStore.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 01/11/2023.
+//
+
+import Foundation
+class ProductionSettingStore: SettingStore {
+    init() {
+        let defaults = UserDefaults.standard
+        super.init(userDefaults: defaults)
+    }
+}

--- a/GymMealPrep/SettingStore/ProductionSettingStore.swift
+++ b/GymMealPrep/SettingStore/ProductionSettingStore.swift
@@ -6,9 +6,14 @@
 //
 
 import Foundation
+
+/// ProductionSettingStore is an interface allowing the app to safely access user settings defined in Setting enum from user defaults.
+///
+/// Production store should be used to manage and read values that user 
 class ProductionSettingStore: SettingStore {
+    private static let suiteName: String = "GymMealPrep"
     init() {
-        let defaults = UserDefaults.standard
+        let defaults = UserDefaults(suiteName: ProductionSettingStore.suiteName)
         super.init(userDefaults: defaults)
     }
 }

--- a/GymMealPrep/SettingStore/SettingStoreable.swift
+++ b/GymMealPrep/SettingStore/SettingStoreable.swift
@@ -7,8 +7,17 @@
 
 import Foundation
 
+/// Protocol like class describing features avaliable in all of the stores
+///
+///  This class provides one property containing settings as a dictionary with Setting as a key values and any? as values. It also provides function to reset the store and a static func to provide default value for all of the settings
+///  Concrete implementations of setting store need to override resetStore and add logic to populate and update the settings dictionary.
 class SettingStoreable: ObservableObject {
     @Published var settings: [Setting : Any?] = .init()
+    
+    
+    /// This function resets the store by removing all of the key value pairs from the underlying storage and settings dictionary. The settings in the storage and dictionary will be replaced by default values.
+    ///
+    /// This method needs to be overriden by inheriting concrete implementations of setting storage. 
     func resetStore() {
         
     }

--- a/GymMealPrep/SettingStore/SettingStoreable.swift
+++ b/GymMealPrep/SettingStore/SettingStoreable.swift
@@ -1,0 +1,12 @@
+//
+//  SettingStoreable.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 31/10/2023.
+//
+
+import Foundation
+
+class SettingStoreable: ObservableObject {
+    @Published var settings: [Setting : Any?] = .init()
+}

--- a/GymMealPrep/SettingStore/SettingStoreable.swift
+++ b/GymMealPrep/SettingStore/SettingStoreable.swift
@@ -20,11 +20,11 @@ extension SettingStoreable {
         case .calorieTarget:
             return Double(3100)
         case .macroTargetProtein:
-            return Double(180)
+            return Double(40)
         case .macroTargetFat:
-            return Double(60)
+            return Double(30)
         case .macroTargetCarb:
-            return Double(120)
+            return Double(30)
         case .numberOfMeals:
             return Int(4)
         case .mealNames:

--- a/GymMealPrep/SettingStore/SettingStoreable.swift
+++ b/GymMealPrep/SettingStore/SettingStoreable.swift
@@ -9,4 +9,36 @@ import Foundation
 
 class SettingStoreable: ObservableObject {
     @Published var settings: [Setting : Any?] = .init()
+    func resetStore() {
+        
+    }
+}
+
+extension SettingStoreable {
+    static func provideDefaultValue(for setting: Setting) -> Any? {
+        switch setting {
+        case .calorieTarget:
+            return Double(3100)
+        case .macroTargetProtein:
+            return Double(180)
+        case .macroTargetFat:
+            return Double(60)
+        case .macroTargetCarb:
+            return Double(120)
+        case .numberOfMeals:
+            return Int(4)
+        case .mealNames:
+            return ["Breakfast", "Lunch", "Dinner", "Supper"]
+        case .groceries:
+            return Calendar.current.date(byAdding: .day, value: 3, to: Date())
+        case .nextPlan:
+            return Calendar.current.date(byAdding: .day, value: 10, to: Date())
+        case .units:
+            return Units.metric
+        case .theme:
+             return Theme.light
+        case .rateApp, .contactUs, .terms, .privacy, .apiReference:
+            return nil
+        }
+    }
 }

--- a/GymMealPrep/SettingStore/TestSettingStore.swift
+++ b/GymMealPrep/SettingStore/TestSettingStore.swift
@@ -1,0 +1,19 @@
+//
+//  TestSettingStore.swift
+//  GymMealPrep
+//
+//  Created by Tomasz Kubiak on 01/11/2023.
+//
+
+import Foundation
+
+class TestSettingStore: SettingStore {
+    init() {
+        let defaults = UserDefaults(suiteName: "test")
+        super.init(userDefaults: defaults)
+    }
+    
+    override func resetStore() {
+        UserDefaults().removePersistentDomain(forName: "test")
+    }
+}

--- a/GymMealPrep/SettingStore/TestSettingStore.swift
+++ b/GymMealPrep/SettingStore/TestSettingStore.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
+/// TestSettingStore is an interface allowing the app to safely access user settings defined in Setting enum from user defaults.
+///
+/// TestSettingStore has a seperate UserDefaults suite with name 'test'. This suite should be used for testing the application, in unit test, integration test and UI test. Setup for UI test should modify settings property and not the user defaults in suite directly
 class TestSettingStore: SettingStore {
+    private static let suiteName: String = "test"
     init() {
-        let defaults = UserDefaults(suiteName: "test")
+        let defaults = UserDefaults(suiteName: TestSettingStore.suiteName)
         super.init(userDefaults: defaults)
-    }
-    
-    override func resetStore() {
-        UserDefaults().removePersistentDomain(forName: "test")
     }
 }

--- a/GymMealPrep/Settings/SettingsDetailView.swift
+++ b/GymMealPrep/Settings/SettingsDetailView.swift
@@ -204,7 +204,7 @@ extension SettingsDetailView {
 
 struct SettingsDetailView_Previews: PreviewProvider {
     private struct PreviewContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         var body: some View {
             NavigationStack {
                 SettingsDetailView(

--- a/GymMealPrep/Settings/SettingsDetailViewModel.swift
+++ b/GymMealPrep/Settings/SettingsDetailViewModel.swift
@@ -13,10 +13,10 @@ class SettingsDetailViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = .init()
     var settingModels: [SettingModel]
     
-    @Published private var settingStore: SettingStore
+    @Published private var settingStore: SettingStoreable
     @Published var settingValues: [Setting : Any] = .init()
     
-    init(settingStore: SettingStore, settingModels: [SettingModel]) {
+    init(settingStore: SettingStoreable, settingModels: [SettingModel]) {
         self.settingStore = settingStore
         self.settingModels = settingModels
         self.settingValues = setSettingValuesDict(settingModels: settingModels)

--- a/GymMealPrep/Settings/SettingsListView.swift
+++ b/GymMealPrep/Settings/SettingsListView.swift
@@ -71,7 +71,7 @@ struct SettingsListView_Previews: PreviewProvider {
         @State private var path: NavigationPath
         
         init() {
-            let tempContainer = Container()
+            let tempContainer = ContainerFactory.build()
             self._container = StateObject(wrappedValue: tempContainer)
             self._vm = StateObject(wrappedValue: SettingsViewModel(settingStore: tempContainer.settingStore))
             self._path = State(wrappedValue: NavigationPath())

--- a/GymMealPrep/Settings/SettingsListView.swift
+++ b/GymMealPrep/Settings/SettingsListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SettingsListView: View {
     @ObservedObject var viewModel: SettingsViewModel
     @Binding var path: NavigationPath
-    @State var testing: Int = 1
+    
     var body: some View {
         VStack {
             List {

--- a/GymMealPrep/Settings/SettingsMacroTargetsView.swift
+++ b/GymMealPrep/Settings/SettingsMacroTargetsView.swift
@@ -67,7 +67,8 @@ struct SettingsMacroTargetsView: View {
                     return 0.0
                 } }
         }()
-        return 0...(100-values.reduce(0.0, +))
+        let upperRange = (100-values.reduce(0.0, +))
+        return 0...upperRange
     }
     
     @ViewBuilder

--- a/GymMealPrep/Settings/SettingsMacroTargetsView.swift
+++ b/GymMealPrep/Settings/SettingsMacroTargetsView.swift
@@ -147,7 +147,7 @@ struct SettingsMacroTargetsView: View {
 struct SwiftUIView_Previews: PreviewProvider {
     
     private struct PreviewContainerView: View {
-        @StateObject private var container = Container()
+        @StateObject private var container = ContainerFactory.build()
         
         var body: some View {
             NavigationStack{

--- a/GymMealPrep/Settings/SettingsTabView.swift
+++ b/GymMealPrep/Settings/SettingsTabView.swift
@@ -53,7 +53,7 @@ struct SettingsTabView: View {
 struct SettingsTabView_Previews: PreviewProvider {
     
     private struct PreviewContainerView: View {
-        @StateObject private var container: Container = .init()
+        @StateObject private var container: Container = ContainerFactory.build()
         
         var body: some View {
             SettingsTabView(viewModel: SettingsViewModel(settingStore: container.settingStore))

--- a/GymMealPrep/Settings/SettingsViewModel.swift
+++ b/GymMealPrep/Settings/SettingsViewModel.swift
@@ -10,11 +10,11 @@ import Combine
 
 class SettingsViewModel: ObservableObject {
     
-    @Published private var settingStore: SettingStore
+    @Published private var settingStore: SettingStoreable
     @Published var settings: [SettingSection] = []
     private var cancellables: Set<AnyCancellable> = .init()
     
-    init(settingStore: SettingStore) {
+    init(settingStore: SettingStoreable) {
         self.settingStore = settingStore
         self.settings = createSettingSections()
         
@@ -25,7 +25,7 @@ class SettingsViewModel: ObservableObject {
                 self.settings = self.createSettingSections()
                 self.objectWillChange.send()
             }.store(in: &cancellables)
-        self.setNumberOfMealsUpdater()
+//        self.setNumberOfMealsUpdater()
     }
     
     private func createSettingSections() -> [SettingSection] {
@@ -37,7 +37,7 @@ class SettingsViewModel: ObservableObject {
                                                     items: [.rateApp, .privacy, .terms, .apiReference, .contactUs])
         return [dietSection, mealPlanSection, calendarSection, variousSection, informationSection]
     }
-    
+    //TODO: REWORK SO IT DOES NOT MESS UP THE UI
     private func setNumberOfMealsUpdater() {
         settingStore.$settings
             .receive(on: RunLoop.main)


### PR DESCRIPTION
In this PR I reworked the setting store and introduced a number of classes that define the behaviour and allow for polymorphism. Following classes were added: 
- SettingStoreable
- SettingStore
- ProductionSettingStore
- PreviewSettingStore
- TestSettingStore

SettingStoreable provides an abstract for all of the setting stores. Setting store inherits from SettingStoreable and provides a general implementation for setting store, with init working with any UserDefaults. Test and Production setting stores inherit from SettingStore and obscure the user defaults suite to a private static class property. PreviewSettingStore inherits directly from SettingStoreable and provides a basic dictionary with setting and default values as it is not needed to have persistent storage for previews. 

With this setup, the amount of code is minimised, changes to how store works can be implemented in one point (SettingStore) and the rest of the app can safely use production, preview and test stores ensuring the code always uses the same suites minimising the amount of possible errors while setting up. 